### PR TITLE
Fix green marl makefile for make 3.82

### DIFF
--- a/apps/output_cpp/gm_graph/src/Makefile
+++ b/apps/output_cpp/gm_graph/src/Makefile
@@ -13,9 +13,9 @@ $(BINDIR)/graph_gen: gen.o graph_generate.o  gm_graph.o
 
 $(LIBDIR)/libgmgraph.a: gm_graph.o gm_runtime.o gm_lock.o
 	$(AR) r $@ $^ 
-    
 
-%o:%cc
+
+%.o: %.cc
 	$(CC) $(CFLAGS) -c $<
 
 clean:


### PR DESCRIPTION
make 3.82 prefers shortest stem over 3.81, which made the implicit rule
"%.o: %.cc" preferred over "%o: %cc"

(see e.g. http://www.electric-cloud.com/blog/2010/08/03/gnu-make-3-82-is-out/)
