### PR TITLE
Fixed bug: lost changes during a Foreach-loop

### DIFF
--- a/apps/output_cpp/gm_graph/inc/gm_collection.h
+++ b/apps/output_cpp/gm_graph/inc/gm_collection.h
@@ -61,7 +61,7 @@ public:
             return iter != end;
         }
 
-        T get_next() {
+        T& get_next() {
             return *(iter++);
         }
 

--- a/src/backend_cpp/gm_cpp_gen.cc
+++ b/src/backend_cpp/gm_cpp_gen.cc
@@ -560,7 +560,11 @@ void gm_cpp_gen::generate_sent_assign(ast_assign* a) {
         ast_id* leftHandSide = a->get_lhs_scala();
         if (leftHandSide->is_instantly_assigned()) { //we have to add the variable declaration here
             Body.push(get_lib()->get_type_string(leftHandSide->getTypeSummary()));
-            Body.push(" ");
+            if(a->is_reference()) {
+                Body.push("& ");
+            } else {
+                Body.push(" ");
+            }
         }
         generate_lhs_id(a->get_lhs_scala());
     } else if (a->is_target_map_entry()) {

--- a/src/backend_cpp/gm_cpp_gen_foreach.cc
+++ b/src/backend_cpp/gm_cpp_gen_foreach.cc
@@ -99,7 +99,7 @@ void gm_cpplib::generate_down_initializer(ast_foreach* f, gm_code_writer& Body) 
         else
             type_name = source->getTypeInfo()->is_node_collection() ? NODE_T : EDGE_T;
 
-        sprintf(str_buf, "%s %s = %s.get_next();", type_name, f->get_iterator()->get_genname(), lst_iter_name);
+        sprintf(str_buf, "%s& %s = %s.get_next();", type_name, f->get_iterator()->get_genname(), lst_iter_name);
         Body.pushln(str_buf);
     } else if (gm_is_iteration_on_neighbors_compatible(iter_type)) {
         const char* alias_name = f->find_info_string(CPPBE_INFO_NEIGHBOR_ITERATOR);

--- a/src/inc/gm_ast.h
+++ b/src/inc/gm_ast.h
@@ -2289,9 +2289,17 @@ public:
         return NULL;
     }
 
+    void set_is_reference(bool is_ref) {
+        isReference = is_ref;
+    }
+
+    bool is_reference() {
+        return isReference;
+    }
+
 protected:
     ast_assign() :
-            ast_sent(AST_ASSIGN), lhs_scala(NULL), lhs_field(NULL), rhs(NULL), bound(NULL), arg_minmax(false), lhs_type(0), assign_type(0), reduce_type(0) {
+            ast_sent(AST_ASSIGN), lhs_scala(NULL), lhs_field(NULL), rhs(NULL), bound(NULL), arg_minmax(false), lhs_type(0), assign_type(0), reduce_type(0), isReference(false) {
     }
 
 private:
@@ -2304,6 +2312,7 @@ private:
     ast_id* bound;  // bounding iterator
 
     bool arg_minmax;
+    bool isReference;
 
     std::list<ast_node*> l_list;
     std::list<ast_expr*> r_list;

--- a/src/opt/gm_syntax_sugar2.cc
+++ b/src/opt/gm_syntax_sugar2.cc
@@ -557,6 +557,7 @@ private:
         }
 
         ast_assign* assign = createAssignStatement();
+        assign->set_is_reference(true);
         statements.push_front(assign);
 
         return newBody;


### PR DESCRIPTION
Fixed bug: Changes made to a collectio during a For/Foreach-loop had no effect.
Now the iterators of these loops are translated to references instead of copies of the collections.
