### PR TITLE
Fixed the bugs in JNI classpath and some other small issues.

### DIFF
--- a/apps/output_cpp/gm_graph/inc/gm_file_handling.h
+++ b/apps/output_cpp/gm_graph/inc/gm_file_handling.h
@@ -16,6 +16,7 @@ class GM_JNI_Handler {
     bool failed();
     JNIEnv *env_;
     JavaVM *jvm_;
+    void printAndClearException();
 
   private:
     GM_JNI_Handler();

--- a/apps/output_cpp/gm_graph/javasrc/HDFSReader.java
+++ b/apps/output_cpp/gm_graph/javasrc/HDFSReader.java
@@ -15,64 +15,64 @@ public class HDFSReader {
     FileSystem fs;
     Path filePath;
     FSDataInputStream fdis;
-	
+
     // Constructor and initialization
     public HDFSReader (String s) {
-	try {
-	    fileName = s;
-	    Configuration conf = new Configuration();
-	    conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/core-site.xml"));
-	    conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/hdfs-site.xml"));
-	    fs = FileSystem.get(conf);
-	    filePath = new Path(fileName);
-	    if ( ! fs.exists(filePath)) {
-		System.out.println ("File does not exist: " + fileName);
-		return;
-	    }
-	    fdis = fs.open(filePath);
-	    in = new BufferedReader(new InputStreamReader(fdis));
-	} catch (Exception e) {
-	    System.err.println (e);
-	}
+        try {
+            fileName = s;
+            Configuration conf = new Configuration();
+            conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/core-site.xml"));
+            conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/hdfs-site.xml"));
+            fs = FileSystem.get(conf);
+            filePath = new Path(fileName);
+            if ( ! fs.exists(filePath)) {
+                System.out.println ("File does not exist: " + fileName);
+                return;
+            }
+            fdis = fs.open(filePath);
+            in = new BufferedReader(new InputStreamReader(fdis));
+        } catch (Exception e) {
+            System.err.println (e);
+        }
     }
-    
+
     // Get the next line from the file
     public String getLine() {
-	try {
-	    return in.readLine();
-	} catch (Exception e) {
-	    System.err.println (e);
-	}
-	return null;
+        try {
+            return in.readLine();
+        } catch (Exception e) {
+            System.err.println (e);
+        }
+        return null;
     }
 
     // Get the a sequence of bytes from the file
     public byte[] getBytes(int num_bytes) {
-	try {
-	    byte[] ret = new byte[num_bytes];
-	    int bytes_read = fdis.read(ret);
-	    if (bytes_read != num_bytes && bytes_read > 0) {
-		// as far as I can tell the only way to handle EOF
-		byte[] ret_short  = new byte[bytes_read];
-		System.arraycopy(ret, 0, ret_short, 0, bytes_read);
-		ret = ret_short;
-	    }
-	    return ret;
-	} catch (Exception e) {
-	    System.err.println (e);
-	}
-	return null;
+        try {
+            byte[] ret = new byte[num_bytes];
+            int bytes_read = fdis.read(ret);
+            if (bytes_read != num_bytes && bytes_read > 0) {
+                // as far as I can tell the only way to handle EOF
+                byte[] ret_short  = new byte[bytes_read];
+                System.arraycopy(ret, 0, ret_short, 0, bytes_read);
+                ret = ret_short;
+            }
+            return ret;
+        } catch (Exception e) {
+            System.err.println (e);
+        }
+        return null;
     }
 
     // Set postion in the file from a given position
     public int seekCurrent(long pos) {
-	try {
-	    fdis.seek(fdis.getPos()+pos);
-	    return 0;
-	} catch (Exception e) {
-	    System.err.println (e);
-	}
-	return -1;
+        try {
+            fdis.seek(fdis.getPos()+pos);
+            return 0;
+        } catch (Exception e) {
+            System.err.println (e);
+        }
+        return -1;
     }
 
     // Reset the pointer (reader) to the start of the file

--- a/apps/output_cpp/gm_graph/javasrc/HDFSWriter.java
+++ b/apps/output_cpp/gm_graph/javasrc/HDFSWriter.java
@@ -10,29 +10,29 @@ import org.apache.hadoop.fs.Path;
  * A Java class thar writes to a text file in HDFS
  */
 public class HDFSWriter {
-	String fileName;
-	BufferedWriter out;
+    String fileName;
+    BufferedWriter out;
     FileSystem fs;
     Path filePath;
     FSDataOutputStream fdos;
-	
-    // Constructor and initialization
-	public HDFSWriter (String s) {
-		try {
-			fileName = s;
-			Configuration conf = new Configuration();
-			conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/core-site.xml"));
-			conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/hdfs-site.xml"));
-			fs = FileSystem.get(conf);
-		    filePath = new Path(fileName);
-			fdos = fs.create(filePath);
-			out = new BufferedWriter(new OutputStreamWriter(fdos));
-		} catch (Exception e) {
-			System.err.println (e);
-		}
-	}
 
-	// Write the string to file
+    // Constructor and initialization
+    public HDFSWriter (String s) {
+        try {
+            fileName = s;
+            Configuration conf = new Configuration();
+            conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/core-site.xml"));
+            conf.addResource(new Path(System.getenv("HADOOP_HOME") + "/conf/hdfs-site.xml"));
+            fs = FileSystem.get(conf);
+            filePath = new Path(fileName);
+            fdos = fs.create(filePath);
+            out = new BufferedWriter(new OutputStreamWriter(fdos));
+        } catch (Exception e) {
+            System.err.println (e);
+        }
+    }
+
+    // Write the string to file
     public void write (String str) {
         try {
             out.write (str, 0, str.length());
@@ -41,23 +41,23 @@ public class HDFSWriter {
             System.err.println (e);
         }
     }
-	
-	// Write the a sequence of bytes to file
+
+    // Write the a sequence of bytes to file
     public void writeBytes (byte[] buf) {
         try {
             fdos.write(buf);
-	    fdos.flush();
-	    fdos.sync();
+            fdos.flush();
+            fdos.sync();
         } catch (Exception e) {
             System.err.println (e);
         }
     }
 
-	// Write the a sequence of bytes to file
+    // Write the a sequence of bytes to file
     public void flush () {
         try {
             fdos.flush ();
-	    fdos.sync();
+            fdos.sync();
         } catch (Exception e) {
             System.err.println (e);
         }
@@ -72,7 +72,7 @@ public class HDFSWriter {
             System.err.println (e);
         }
     }
-    
+
     // A sample usage for HDFSWriter
     //     - Only used for debugging purposes
     public static void main(String[] args) {

--- a/apps/output_cpp/gm_graph/src/gm_file_handling.cc
+++ b/apps/output_cpp/gm_graph/src/gm_file_handling.cc
@@ -104,7 +104,7 @@ void GM_Reader::initialize() {
         // Find the HDFSReader class
         cls_ = env_->FindClass("HDFSReader");
         if (cls_ == 0) {
-            fprintf (stderr, "JNI Error: Cannot find class\n");
+            fprintf (stderr, "JNI Error: Cannot find class HDFSReader\n");
             failed_ = true;
             return;
         }
@@ -112,7 +112,7 @@ void GM_Reader::initialize() {
         // Get the methodID of the constructor of HDFSReader class that takes java.lang.String as the only input parameter
         jmethodID readerConstructor = env_->GetMethodID(cls_, "<init>", "(Ljava/lang/String;)V");
         if (readerConstructor == 0) {
-            fprintf (stderr, "JNI Error: Cannot get Constructor\n");
+            fprintf (stderr, "JNI Error: Cannot get the constructor of HDFSReader class\n");
             failed_ = true;
             return;
         }
@@ -120,7 +120,7 @@ void GM_Reader::initialize() {
         // Create a new object of HDFSReader class, and also invoke its constructor
         readerObj_ = env_->NewObject(cls_, readerConstructor, env_->NewStringUTF(filename_.c_str()));
         if (readerObj_ == 0) {
-            fprintf (stderr, "JNI Error: Cannot create new object of Reader class\n");
+            fprintf (stderr, "JNI Error: Cannot create new object of HDFSReader class\n");
             failed_ = true;
             return;
         }
@@ -128,7 +128,7 @@ void GM_Reader::initialize() {
         // Get the methodID of getLine in HDFSReader class
         getLineMethod_ = env_->GetMethodID(cls_, "getLine", "()Ljava/lang/String;");
         if (getLineMethod_ == 0) {
-            fprintf (stderr, "JNI Error: Cannot get getLine method in Reader\n");
+            fprintf (stderr, "JNI Error: Cannot get getLine method in HDFSReader\n");
             failed_ = true;
             return;
         }
@@ -136,7 +136,7 @@ void GM_Reader::initialize() {
         // Get the methodID of getBytes in HDFSReader class
         getBytesMethod_ = env_->GetMethodID(cls_, "getBytes", "(I)[B");
         if (getBytesMethod_ == 0) {
-            fprintf (stderr, "JNI Error: Cannot get getBytes method in Reader\n");
+            fprintf (stderr, "JNI Error: Cannot get getBytes method in HDFSReader\n");
             failed_ = true;
             return;
         }
@@ -144,7 +144,7 @@ void GM_Reader::initialize() {
         // Get the methodID of seekCurrent in HDFSReader class
         seekCurrentMethod_ = env_->GetMethodID(cls_, "seekCurrent", "(J)I");
         if (seekCurrentMethod_ == 0) {
-            fprintf (stderr, "JNI Error: Cannot get seekCurrent method in Reader\n");
+            fprintf (stderr, "JNI Error: Cannot get seekCurrent method in HDFSReader\n");
             failed_ = true;
             return;
         }
@@ -178,7 +178,7 @@ void GM_Reader::reset() {
         // Get the methodID of reset in HDFSReader class
         jmethodID resetMethod = env_->GetMethodID(cls_, "reset", "()V");
         if (resetMethod == 0) {
-            fprintf (stderr, "JNI Error: Cannot get reset method in Reader\n");
+            fprintf (stderr, "JNI Error: Cannot get reset method in HDFSReader\n");
             failed_ = true;
             return;
         }
@@ -270,7 +270,7 @@ void GM_Reader::terminate() {
         // Get the methodID of terminate in HDFSReader class
         jmethodID terminateMethod = env_->GetMethodID(cls_, "terminate", "()V");
         if (terminateMethod == 0) {
-            fprintf (stderr, "JNI Error: Cannot get terminate method in Reader\n");
+            fprintf (stderr, "JNI Error: Cannot get terminate method in HDFSReader\n");
             failed_ = true;
             return;
         }

--- a/apps/output_cpp/gm_graph/src/gm_file_handling.cc
+++ b/apps/output_cpp/gm_graph/src/gm_file_handling.cc
@@ -73,6 +73,13 @@ GM_JNI_Handler::~GM_JNI_Handler() {
     }
 }
 
+void GM_JNI_Handler::printAndClearException() {
+    if (env_->ExceptionOccurred()) {
+        env_->ExceptionDescribe();
+        env_->ExceptionClear();
+    }
+}
+
 #endif
 
 /***********************************************************
@@ -104,6 +111,7 @@ void GM_Reader::initialize() {
         // Find the HDFSReader class
         cls_ = env_->FindClass("HDFSReader");
         if (cls_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot find class HDFSReader\n");
             failed_ = true;
             return;
@@ -112,6 +120,7 @@ void GM_Reader::initialize() {
         // Get the methodID of the constructor of HDFSReader class that takes java.lang.String as the only input parameter
         jmethodID readerConstructor = env_->GetMethodID(cls_, "<init>", "(Ljava/lang/String;)V");
         if (readerConstructor == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get the constructor of HDFSReader class\n");
             failed_ = true;
             return;
@@ -120,6 +129,7 @@ void GM_Reader::initialize() {
         // Create a new object of HDFSReader class, and also invoke its constructor
         readerObj_ = env_->NewObject(cls_, readerConstructor, env_->NewStringUTF(filename_.c_str()));
         if (readerObj_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot create new object of HDFSReader class\n");
             failed_ = true;
             return;
@@ -128,6 +138,7 @@ void GM_Reader::initialize() {
         // Get the methodID of getLine in HDFSReader class
         getLineMethod_ = env_->GetMethodID(cls_, "getLine", "()Ljava/lang/String;");
         if (getLineMethod_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get getLine method in HDFSReader\n");
             failed_ = true;
             return;
@@ -136,6 +147,7 @@ void GM_Reader::initialize() {
         // Get the methodID of getBytes in HDFSReader class
         getBytesMethod_ = env_->GetMethodID(cls_, "getBytes", "(I)[B");
         if (getBytesMethod_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get getBytes method in HDFSReader\n");
             failed_ = true;
             return;
@@ -144,6 +156,7 @@ void GM_Reader::initialize() {
         // Get the methodID of seekCurrent in HDFSReader class
         seekCurrentMethod_ = env_->GetMethodID(cls_, "seekCurrent", "(J)I");
         if (seekCurrentMethod_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get seekCurrent method in HDFSReader\n");
             failed_ = true;
             return;
@@ -178,6 +191,7 @@ void GM_Reader::reset() {
         // Get the methodID of reset in HDFSReader class
         jmethodID resetMethod = env_->GetMethodID(cls_, "reset", "()V");
         if (resetMethod == 0) {
+            GM_JNI_Handler::getInstance()->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get reset method in HDFSReader\n");
             failed_ = true;
             return;
@@ -209,6 +223,7 @@ bool GM_Reader::getNextLine(std::string &line) {
         // Convert the return object into C string
         const char* str = env_->GetStringUTFChars((jstring) strObj, NULL);
         if (str == 0) {
+            GM_JNI_Handler::getInstance()->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot convert java.lang.String to C String\n");
             return false;
         }
@@ -270,6 +285,7 @@ void GM_Reader::terminate() {
         // Get the methodID of terminate in HDFSReader class
         jmethodID terminateMethod = env_->GetMethodID(cls_, "terminate", "()V");
         if (terminateMethod == 0) {
+            GM_JNI_Handler::getInstance()->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get terminate method in HDFSReader\n");
             failed_ = true;
             return;
@@ -305,6 +321,7 @@ void GM_Writer::initialize () {
         // Get the JNI environment from the GM_JNI_Handler
         GM_JNI_Handler *jni_handler = GM_JNI_Handler::getInstance();
         if (jni_handler->failed()) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Initialization failed\n");
             failed_ = true;
             return;
@@ -314,6 +331,7 @@ void GM_Writer::initialize () {
         // Find the HDFSWriter class
         cls_ = env_->FindClass("HDFSWriter");
         if (cls_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot find class HDFSWriter\n");
             failed_ = true;
             return;
@@ -323,6 +341,7 @@ void GM_Writer::initialize () {
         // Get the methodID of the constructor of HDFSWriter class that takes java.lang.String as the only input parameter
         jmethodID writerConstructor = env_->GetMethodID(cls_, "<init>", "(Ljava/lang/String;)V");
         if (writerConstructor == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get Constructor of HDFSWriter class with String as the only input parameter\n");
             failed_ = true;
             return;
@@ -331,6 +350,7 @@ void GM_Writer::initialize () {
         // Create a new object of HDFSWriter class, and also invoke its constructor
         writerObj_ = env_->NewObject(cls_, writerConstructor, env_->NewStringUTF(filename_.c_str()));
         if (writerObj_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot create new object of HDFSWriter class\n");
             failed_ = true;
             return;
@@ -339,6 +359,7 @@ void GM_Writer::initialize () {
         // Get the methodID of getLine in HDFSWriter class
         writeMethod_ = env_->GetMethodID(cls_, "write", "(Ljava/lang/String;)V");
         if (writeMethod_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get write method in HDFSWriter\n");
             failed_ = true;
             return;
@@ -347,6 +368,7 @@ void GM_Writer::initialize () {
         // Get the methodID of writeBytes in HDFSWriter class
         writeBytesMethod_ = env_->GetMethodID(cls_, "writeBytes", "([B)V");
         if (writeBytesMethod_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get writeBytes method in HDFSWriter\n");
             failed_ = true;
             return;
@@ -355,6 +377,7 @@ void GM_Writer::initialize () {
         // Get the methodID of flush in HDFSWriter class
         flushMethod_ = env_->GetMethodID(cls_, "flush", "()V");
         if (flushMethod_ == 0) {
+            jni_handler->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get flush method in HDFSWriter\n");
             failed_ = true;
             return;
@@ -385,6 +408,7 @@ void GM_Writer::terminate() {
         // Get the methodID of terminate in HDFSWriter class
         jmethodID terminateMethod = env_->GetMethodID(cls_, "terminate", "()V");
         if (terminateMethod == 0) {
+            GM_JNI_Handler::getInstance()->printAndClearException();
             fprintf (stderr, "JNI Error: Cannot get terminate method in HDFSWriter\n");
             failed_ = true;
             return;

--- a/apps/output_cpp/gm_graph/src/gm_file_handling.cc
+++ b/apps/output_cpp/gm_graph/src/gm_file_handling.cc
@@ -37,8 +37,8 @@ GM_JNI_Handler::GM_JNI_Handler() {
     const char* GMTop         = getenv("GM_TOP") == NULL ? "" : getenv("GM_TOP");
     const char* HadoopHome    = getenv("HADOOP_HOME") == NULL ? "" : getenv("HADOOP_HOME");
     const char* HadoopCoreJar = getenv("HADOOP_CORE_JAR") == NULL ? "" : getenv("HADOOP_CORE_JAR");
-    const char* LoggingJar = "commons-logging-1.0.4.jar";
-    const char* GuavaJar = "guava-r09-jarjar.jar";
+    const char* LoggingJar = getenv("HADOOP_COMMONS_LOGGING_JAR"); 
+    const char* GuavaJar = getenv("HADOOP_GUAVA_R09_JAR"); 
 
     sprintf(buffer, "-Djava.class.path=%s/%s:%s/lib/%s:%s/lib/%s:%s/apps/output_cpp/gm_graph/javabin/", 
             HadoopHome, HadoopCoreJar,

--- a/apps/output_cpp/gm_graph/src/gm_file_handling.cc
+++ b/apps/output_cpp/gm_graph/src/gm_file_handling.cc
@@ -89,82 +89,82 @@ GM_Reader::GM_Reader (const char *filename, bool hdfs) {
 }
 
 void GM_Reader::initialize() {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    // Initialize for reading a file from HDFS
-    // Get the JNI environment from the GM_JNI_Handler
-    GM_JNI_Handler *jni_handler = GM_JNI_Handler::getInstance();
-    if (jni_handler->failed()) {
-        fprintf (stderr, "JNI Error: Initialization failed\n");
-        failed_ = true;
-        return;
-    }
-    env_ = jni_handler->env_;
+        // Initialize for reading a file from HDFS
+        // Get the JNI environment from the GM_JNI_Handler
+        GM_JNI_Handler *jni_handler = GM_JNI_Handler::getInstance();
+        if (jni_handler->failed()) {
+            fprintf (stderr, "JNI Error: Initialization failed\n");
+            failed_ = true;
+            return;
+        }
+        env_ = jni_handler->env_;
 
-    // Find the HDFSReader class
-    cls_ = env_->FindClass("HDFSReader");
-    if (cls_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot find class\n");
-        failed_ = true;
-        return;
-    }
+        // Find the HDFSReader class
+        cls_ = env_->FindClass("HDFSReader");
+        if (cls_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot find class\n");
+            failed_ = true;
+            return;
+        }
 
-    // Get the methodID of the constructor of HDFSReader class that takes java.lang.String as the only input parameter
-    jmethodID readerConstructor = env_->GetMethodID(cls_, "<init>", "(Ljava/lang/String;)V");
-    if (readerConstructor == 0) {
-        fprintf (stderr, "JNI Error: Cannot get Constructor\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of the constructor of HDFSReader class that takes java.lang.String as the only input parameter
+        jmethodID readerConstructor = env_->GetMethodID(cls_, "<init>", "(Ljava/lang/String;)V");
+        if (readerConstructor == 0) {
+            fprintf (stderr, "JNI Error: Cannot get Constructor\n");
+            failed_ = true;
+            return;
+        }
 
-    // Create a new object of HDFSReader class, and also invoke its constructor
-    readerObj_ = env_->NewObject(cls_, readerConstructor, env_->NewStringUTF(filename_.c_str()));
-    if (readerObj_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot create new object of Reader class\n");
-        failed_ = true;
-        return;
-    }
+        // Create a new object of HDFSReader class, and also invoke its constructor
+        readerObj_ = env_->NewObject(cls_, readerConstructor, env_->NewStringUTF(filename_.c_str()));
+        if (readerObj_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot create new object of Reader class\n");
+            failed_ = true;
+            return;
+        }
 
-    // Get the methodID of getLine in HDFSReader class
-    getLineMethod_ = env_->GetMethodID(cls_, "getLine", "()Ljava/lang/String;");
-    if (getLineMethod_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot get getLine method in Reader\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of getLine in HDFSReader class
+        getLineMethod_ = env_->GetMethodID(cls_, "getLine", "()Ljava/lang/String;");
+        if (getLineMethod_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot get getLine method in Reader\n");
+            failed_ = true;
+            return;
+        }
 
-    // Get the methodID of getBytes in HDFSReader class
-    getBytesMethod_ = env_->GetMethodID(cls_, "getBytes", "(I)[B");
-    if (getBytesMethod_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot get getBytes method in Reader\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of getBytes in HDFSReader class
+        getBytesMethod_ = env_->GetMethodID(cls_, "getBytes", "(I)[B");
+        if (getBytesMethod_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot get getBytes method in Reader\n");
+            failed_ = true;
+            return;
+        }
 
-    // Get the methodID of seekCurrent in HDFSReader class
-    seekCurrentMethod_ = env_->GetMethodID(cls_, "seekCurrent", "(J)I");
-    if (seekCurrentMethod_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot get seekCurrent method in Reader\n");
-        failed_ = true;
-        return;
-    }
-    failed_ = false;
+        // Get the methodID of seekCurrent in HDFSReader class
+        seekCurrentMethod_ = env_->GetMethodID(cls_, "seekCurrent", "(J)I");
+        if (seekCurrentMethod_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot get seekCurrent method in Reader\n");
+            failed_ = true;
+            return;
+        }
+        failed_ = false;
 #else
-    failed_ = true;
-    return;
-#endif  // HDFS
-}
-//#else
-else {
-    // Initialize for reading a file from NFS
-    fs_.open(filename_.c_str());
-    failed_ = false;
-    if (fs_.fail()) {
-        fprintf (stderr, "Cannot open %s for reading\n", filename_.c_str());
         failed_ = true;
+        return;
+#endif  // HDFS
     }
-}
-//#endif  // HDFS
+    //#else
+    else {
+        // Initialize for reading a file from NFS
+        fs_.open(filename_.c_str());
+        failed_ = false;
+        if (fs_.fail()) {
+            fprintf (stderr, "Cannot open %s for reading\n", filename_.c_str());
+            failed_ = true;
+        }
+    }
+    //#endif  // HDFS
 }
 
 bool GM_Reader::failed() {
@@ -172,117 +172,117 @@ bool GM_Reader::failed() {
 }
 
 void GM_Reader::reset() {
-if (hdfs_)
-{
+    if (hdfs_)
+    {
 #ifdef HDFS
-    // Get the methodID of reset in HDFSReader class
-    jmethodID resetMethod = env_->GetMethodID(cls_, "reset", "()V");
-    if (resetMethod == 0) {
-        fprintf (stderr, "JNI Error: Cannot get reset method in Reader\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of reset in HDFSReader class
+        jmethodID resetMethod = env_->GetMethodID(cls_, "reset", "()V");
+        if (resetMethod == 0) {
+            fprintf (stderr, "JNI Error: Cannot get reset method in Reader\n");
+            failed_ = true;
+            return;
+        }
 
-    // Call the reset method in HDFSReader class
-    env_->CallVoidMethod(readerObj_, resetMethod);
+        // Call the reset method in HDFSReader class
+        env_->CallVoidMethod(readerObj_, resetMethod);
 #endif
-}
-else {
-    fs_.clear();
-    fs_.seekg(0, std::ios::beg);
-    if (fs_.fail()) {
-        fprintf (stderr, "Error moving file pointer to the beginning of file %s\n", filename_.c_str());
     }
-}
+    else {
+        fs_.clear();
+        fs_.seekg(0, std::ios::beg);
+        if (fs_.fail()) {
+            fprintf (stderr, "Error moving file pointer to the beginning of file %s\n", filename_.c_str());
+        }
+    }
 }
 
 bool GM_Reader::getNextLine(std::string &line) {
-if (hdfs_)
-{
+    if (hdfs_)
+    {
 #ifdef HDFS
-    // Call getLine method in HDFSReader class
-    jobject strObj = env_->CallObjectMethod(readerObj_, getLineMethod_, "");
-    if (strObj == 0) {
-        return false; // indicating end of file
-    }
+        // Call getLine method in HDFSReader class
+        jobject strObj = env_->CallObjectMethod(readerObj_, getLineMethod_, "");
+        if (strObj == 0) {
+            return false; // indicating end of file
+        }
 
-    // Convert the return object into C string
-    const char* str = env_->GetStringUTFChars((jstring) strObj, NULL);
-    if (str == 0) {
-        fprintf (stderr, "JNI Error: Cannot convert java.lang.String to C String\n");
-        return false;
-    }
-    line = str;
-    env_->ReleaseStringUTFChars((jstring) strObj, str);
-    return true;
+        // Convert the return object into C string
+        const char* str = env_->GetStringUTFChars((jstring) strObj, NULL);
+        if (str == 0) {
+            fprintf (stderr, "JNI Error: Cannot convert java.lang.String to C String\n");
+            return false;
+        }
+        line = str;
+        env_->ReleaseStringUTFChars((jstring) strObj, str);
+        return true;
 #else
-    return false;
+        return false;
 #endif // HDFS
-} else {
-    std::getline(fs_, line);
-    return ! fs_.fail();
-}
+    } else {
+        std::getline(fs_, line);
+        return ! fs_.fail();
+    }
 }
 
 int GM_Reader::readBytes(char* buf, size_t num_bytes) {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    // Call getBytes method in HDFSReader class
-    jobject byteArray = env_->CallObjectMethod(readerObj_, getBytesMethod_, (jint)num_bytes);
-    if (byteArray == 0) {
-        return 0;
-    }
-    jbyte* bytes = env_->GetByteArrayElements((jbyteArray) byteArray, NULL);
-    if (bytes == NULL) {
-	return 0;
-    }
-    int bytes_read = env_->GetArrayLength((jarray)byteArray);
-    memcpy(buf, bytes, bytes_read);
-    env_->ReleaseByteArrayElements((jbyteArray) byteArray, bytes, JNI_ABORT); // no changes to copy back
-    return bytes_read;
+        // Call getBytes method in HDFSReader class
+        jobject byteArray = env_->CallObjectMethod(readerObj_, getBytesMethod_, (jint)num_bytes);
+        if (byteArray == 0) {
+            return 0;
+        }
+        jbyte* bytes = env_->GetByteArrayElements((jbyteArray) byteArray, NULL);
+        if (bytes == NULL) {
+            return 0;
+        }
+        int bytes_read = env_->GetArrayLength((jarray)byteArray);
+        memcpy(buf, bytes, bytes_read);
+        env_->ReleaseByteArrayElements((jbyteArray) byteArray, bytes, JNI_ABORT); // no changes to copy back
+        return bytes_read;
 #else
-    return 0;
+        return 0;
 #endif
-} else {
-    fs_.read(buf, num_bytes);
-    return fs_.gcount();
-}
+    } else {
+        fs_.read(buf, num_bytes);
+        return fs_.gcount();
+    }
 }
 
 int GM_Reader::seekCurrent(long int pos) {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    // Call seekCurrent method in HDFSReader class
-    return env_->CallIntMethod(readerObj_, seekCurrentMethod_, (jlong)pos);
+        // Call seekCurrent method in HDFSReader class
+        return env_->CallIntMethod(readerObj_, seekCurrentMethod_, (jlong)pos);
 #else
-    return 0;
+        return 0;
 #endif
-} else {
-    fs_.seekg(pos, std::ios::cur);    
-    return 0; // TODO: error check?
-}
+    } else {
+        fs_.seekg(pos, std::ios::cur);    
+        return 0; // TODO: error check?
+    }
 }
 
 
 void GM_Reader::terminate() {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    // Get the methodID of terminate in HDFSReader class
-    jmethodID terminateMethod = env_->GetMethodID(cls_, "terminate", "()V");
-    if (terminateMethod == 0) {
-        fprintf (stderr, "JNI Error: Cannot get terminate method in Reader\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of terminate in HDFSReader class
+        jmethodID terminateMethod = env_->GetMethodID(cls_, "terminate", "()V");
+        if (terminateMethod == 0) {
+            fprintf (stderr, "JNI Error: Cannot get terminate method in Reader\n");
+            failed_ = true;
+            return;
+        }
 
-    // Call the terminate method in HDFSReader class
-    env_->CallVoidMethod(readerObj_, terminateMethod);
+        // Call the terminate method in HDFSReader class
+        env_->CallVoidMethod(readerObj_, terminateMethod);
 #else
-    return ;
+        return ;
 #endif
-} else {
-    fs_.close();
-}
+    } else {
+        fs_.close();
+    }
 }
 
 /***********************************************************
@@ -299,79 +299,79 @@ GM_Writer::GM_Writer (const char *filename, bool hdfs) {
 }
 
 void GM_Writer::initialize () {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    // Initialize for writing a file to HDFS
-    // Get the JNI environment from the GM_JNI_Handler
-    GM_JNI_Handler *jni_handler = GM_JNI_Handler::getInstance();
-    if (jni_handler->failed()) {
-        fprintf (stderr, "JNI Error: Initialization failed\n");
-        failed_ = true;
-        return;
-    }
-    env_ = jni_handler->env_;
+        // Initialize for writing a file to HDFS
+        // Get the JNI environment from the GM_JNI_Handler
+        GM_JNI_Handler *jni_handler = GM_JNI_Handler::getInstance();
+        if (jni_handler->failed()) {
+            fprintf (stderr, "JNI Error: Initialization failed\n");
+            failed_ = true;
+            return;
+        }
+        env_ = jni_handler->env_;
 
-    // Find the HDFSWriter class
-    cls_ = env_->FindClass("HDFSWriter");
-    if (cls_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot find class HDFSWriter\n");
-        failed_ = true;
-        return;
-    }
+        // Find the HDFSWriter class
+        cls_ = env_->FindClass("HDFSWriter");
+        if (cls_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot find class HDFSWriter\n");
+            failed_ = true;
+            return;
+        }
 
 
-    // Get the methodID of the constructor of HDFSWriter class that takes java.lang.String as the only input parameter
-    jmethodID writerConstructor = env_->GetMethodID(cls_, "<init>", "(Ljava/lang/String;)V");
-    if (writerConstructor == 0) {
-        fprintf (stderr, "JNI Error: Cannot get Constructor of HDFSWriter class with String as the only input parameter\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of the constructor of HDFSWriter class that takes java.lang.String as the only input parameter
+        jmethodID writerConstructor = env_->GetMethodID(cls_, "<init>", "(Ljava/lang/String;)V");
+        if (writerConstructor == 0) {
+            fprintf (stderr, "JNI Error: Cannot get Constructor of HDFSWriter class with String as the only input parameter\n");
+            failed_ = true;
+            return;
+        }
 
-    // Create a new object of HDFSWriter class, and also invoke its constructor
-    writerObj_ = env_->NewObject(cls_, writerConstructor, env_->NewStringUTF(filename_.c_str()));
-    if (writerObj_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot create new object of HDFSWriter class\n");
-        failed_ = true;
-        return;
-    }
+        // Create a new object of HDFSWriter class, and also invoke its constructor
+        writerObj_ = env_->NewObject(cls_, writerConstructor, env_->NewStringUTF(filename_.c_str()));
+        if (writerObj_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot create new object of HDFSWriter class\n");
+            failed_ = true;
+            return;
+        }
 
-    // Get the methodID of getLine in HDFSWriter class
-    writeMethod_ = env_->GetMethodID(cls_, "write", "(Ljava/lang/String;)V");
-    if (writeMethod_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot get write method in HDFSWriter\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of getLine in HDFSWriter class
+        writeMethod_ = env_->GetMethodID(cls_, "write", "(Ljava/lang/String;)V");
+        if (writeMethod_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot get write method in HDFSWriter\n");
+            failed_ = true;
+            return;
+        }
 
-    // Get the methodID of writeBytes in HDFSWriter class
-    writeBytesMethod_ = env_->GetMethodID(cls_, "writeBytes", "([B)V");
-    if (writeBytesMethod_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot get writeBytes method in HDFSWriter\n");
-        failed_ = true;
-        return;
-    }
+        // Get the methodID of writeBytes in HDFSWriter class
+        writeBytesMethod_ = env_->GetMethodID(cls_, "writeBytes", "([B)V");
+        if (writeBytesMethod_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot get writeBytes method in HDFSWriter\n");
+            failed_ = true;
+            return;
+        }
 
-    // Get the methodID of flush in HDFSWriter class
-    flushMethod_ = env_->GetMethodID(cls_, "flush", "()V");
-    if (flushMethod_ == 0) {
-        fprintf (stderr, "JNI Error: Cannot get flush method in HDFSWriter\n");
-        failed_ = true;
-        return;
-    }
-    failed_ = false;
+        // Get the methodID of flush in HDFSWriter class
+        flushMethod_ = env_->GetMethodID(cls_, "flush", "()V");
+        if (flushMethod_ == 0) {
+            fprintf (stderr, "JNI Error: Cannot get flush method in HDFSWriter\n");
+            failed_ = true;
+            return;
+        }
+        failed_ = false;
 #else
-    failed_ = true;
+        failed_ = true;
 #endif // HDFS
-} else {
-   // Initialize for writing a file to NFS
-   outstreamfs_.open(filename_.c_str());
-   failed_ = false;
-   if (outstreamfs_.fail()) {
-       fprintf (stderr, "Cannot open %s for writing\n", filename_.c_str());
-       failed_ = true;
-   }
-}
+    } else {
+        // Initialize for writing a file to NFS
+        outstreamfs_.open(filename_.c_str());
+        failed_ = false;
+        if (outstreamfs_.fail()) {
+            fprintf (stderr, "Cannot open %s for writing\n", filename_.c_str());
+            failed_ = true;
+        }
+    }
 }
 
 bool GM_Writer::failed() {
@@ -379,24 +379,24 @@ bool GM_Writer::failed() {
 }
 
 void GM_Writer::terminate() {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    flush();
-    // Get the methodID of terminate in HDFSWriter class
-    jmethodID terminateMethod = env_->GetMethodID(cls_, "terminate", "()V");
-    if (terminateMethod == 0) {
-        fprintf (stderr, "JNI Error: Cannot get terminate method in HDFSWriter\n");
-        failed_ = true;
-        return;
-    }
-    // Call the terminate method in HDFSWriter class
-    env_->CallVoidMethod(writerObj_, terminateMethod);
+        flush();
+        // Get the methodID of terminate in HDFSWriter class
+        jmethodID terminateMethod = env_->GetMethodID(cls_, "terminate", "()V");
+        if (terminateMethod == 0) {
+            fprintf (stderr, "JNI Error: Cannot get terminate method in HDFSWriter\n");
+            failed_ = true;
+            return;
+        }
+        // Call the terminate method in HDFSWriter class
+        env_->CallVoidMethod(writerObj_, terminateMethod);
 #else 
-    return;
+        return;
 #endif
-} else {
-    outstreamfs_.close();
-}
+    } else {
+        outstreamfs_.close();
+    }
 }
 
 #ifdef HDFS 
@@ -406,13 +406,13 @@ if (hdfs_) {
 #endif
 
 void GM_Writer::write (bool val) {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    outstream_ << std::boolalpha << val;
+        outstream_ << std::boolalpha << val;
 #endif
-} else {
-    outstreamfs_ << std::boolalpha << val;
-}
+    } else {
+        outstreamfs_ << std::boolalpha << val;
+    }
 }
 
 void GM_Writer::write (int val) {
@@ -440,38 +440,38 @@ void GM_Writer::write (std::string &val) {
 }
 
 void GM_Writer::writeBytes(char* buf, size_t num_bytes) {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    jobject byteArray = env_->NewByteArray((jsize)num_bytes);
-    env_->SetByteArrayRegion((jbyteArray)byteArray, 0, num_bytes, (jbyte*)buf);
-    env_->CallVoidMethod(writerObj_, writeBytesMethod_, byteArray);
+        jobject byteArray = env_->NewByteArray((jsize)num_bytes);
+        env_->SetByteArrayRegion((jbyteArray)byteArray, 0, num_bytes, (jbyte*)buf);
+        env_->CallVoidMethod(writerObj_, writeBytesMethod_, byteArray);
 #else
-    return;
+        return;
 #endif
-}
-else {
-  outstreamfs_.write(buf, num_bytes);
-}
+    }
+    else {
+        outstreamfs_.write(buf, num_bytes);
+    }
 }
 
 
 void GM_Writer::flush () {
-if (hdfs_) {
+    if (hdfs_) {
 #ifdef HDFS
-    if (outstream_.str() == "") {
-	env_->CallVoidMethod(writerObj_, flushMethod_, "");
-    }
-    else {
-	// write the stringstream to file through a JNI call
-	// Call write method in HDFSWriter class
-	env_->CallVoidMethod(writerObj_, writeMethod_, env_->NewStringUTF(outstream_.str().c_str()));
-	// clear the stringstream object
-	outstream_.str("");
-	outstream_.clear();
-    }
+        if (outstream_.str() == "") {
+            env_->CallVoidMethod(writerObj_, flushMethod_, "");
+        }
+        else {
+            // write the stringstream to file through a JNI call
+            // Call write method in HDFSWriter class
+            env_->CallVoidMethod(writerObj_, writeMethod_, env_->NewStringUTF(outstream_.str().c_str()));
+            // clear the stringstream object
+            outstream_.str("");
+            outstream_.clear();
+        }
 #else
 #endif
-} else {
-    outstreamfs_.flush();
-} 
+    } else {
+        outstreamfs_.flush();
+    } 
 }

--- a/apps/output_cpp/gm_graph/src/gm_file_handling.cc
+++ b/apps/output_cpp/gm_graph/src/gm_file_handling.cc
@@ -38,7 +38,7 @@ GM_JNI_Handler::GM_JNI_Handler() {
     const char* HadoopHome    = getenv("HADOOP_HOME") == NULL ? "" : getenv("HADOOP_HOME");
     const char* HadoopCoreJar = getenv("HADOOP_CORE_JAR") == NULL ? "" : getenv("HADOOP_CORE_JAR");
     const char* LoggingJar = "commons-logging-1.0.4.jar";
-    const char* GuavaJar = "guava-r09-jarjara.jar";
+    const char* GuavaJar = "guava-r09-jarjar.jar";
 
     sprintf(buffer, "-Djava.class.path=%s/%s:%s/lib/%s:%s/lib/%s:%s/apps/output_cpp/gm_graph/javabin/ -XX:+UseOSErrorReporting", 
             HadoopHome, HadoopCoreJar,

--- a/apps/output_cpp/gm_graph/src/gm_file_handling.cc
+++ b/apps/output_cpp/gm_graph/src/gm_file_handling.cc
@@ -40,7 +40,7 @@ GM_JNI_Handler::GM_JNI_Handler() {
     const char* LoggingJar = "commons-logging-1.0.4.jar";
     const char* GuavaJar = "guava-r09-jarjar.jar";
 
-    sprintf(buffer, "-Djava.class.path=%s/%s:%s/lib/%s:%s/lib/%s:%s/apps/output_cpp/gm_graph/javabin/ -XX:+UseOSErrorReporting", 
+    sprintf(buffer, "-Djava.class.path=%s/%s:%s/lib/%s:%s/lib/%s:%s/apps/output_cpp/gm_graph/javabin/", 
             HadoopHome, HadoopCoreJar,
             HadoopHome, LoggingJar,
             HadoopHome, GuavaJar, 

--- a/setup.mk.in
+++ b/setup.mk.in
@@ -15,6 +15,8 @@ JAVA_HOME=/usr/java/default
 # Name of hadoop core jar (For HDFS support and Giraph backend)
 HADOOP_CORE_JAR=hadoop-core-0.20.2-cdh3u4.jar
 #HADOOP_CORE_JAR=hadoop-core-1.0.3.jar
+HADOOP_COMMONS_LOGGING_JAR=commons-logging-1.0.4.jar
+HADOOP_GUAVA_R09_JAR=guava-r09-jarjar.jar
 
 
 #-------------------------------------------------------------


### PR DESCRIPTION
- Fixed the bug in the JNI classpath due to incorrect jar name.
- Fixed the bug in the JNI classpath due to an extra space at the end of the generated class path string.
- Added environment variables in setup.mk.in for commons-logging jar and guava jar.
- Added reference to the above environment variables in gm_file_handling to build the class path string.
- Fixed indentation issues in gm_file_handling.cc, HDFSReader.java, and HDFSWriter.java.
