### PR TITLE
Fix bug in ATOMIC_AND and ATOMIC_OR

### DIFF
--- a/apps/output_cpp/gm_graph/src/gm_atomic_operations.cc
+++ b/apps/output_cpp/gm_graph/src/gm_atomic_operations.cc
@@ -1,9 +1,9 @@
 #include "gm_atomic_wrapper.h"
 
 void ATOMIC_AND(bool* target, bool value) {
-    if ((!value) || (*target)) *target = false;
+    if (!value && *target) *target = false;
 }
 
 void ATOMIC_OR(bool* target, bool value) {
-    if ((value) && (*target)) *target = true;
+    if (value && !(*target)) *target = true;
 }


### PR DESCRIPTION
this should work too right?

void ATOMIC_AND(bool\* target, bool value) {
   if (!value) *target = false;  
}

void ATOMIC_OR(bool\* target, bool value) {
   if (value) *target = true;
}
