### PR TITLE
Update gm_copy.cc

### DIFF
--- a/src/common/gm_copy.cc
+++ b/src/common/gm_copy.cc
@@ -77,9 +77,7 @@ ast_expr* ast_expr_builtin::copy(bool b) {
         T->LIST.push_back(e2);
     }
 
-    ast_expr_builtin* e = ast_expr_builtin::new_builtin_expr(driver->copy(b), orgname, T);
-
-    delete T;
+    ast_expr_builtin* e = ast_expr_builtin::new_builtin_expr(driver->copy(b), get_builtin_def(), T);
 
     e->set_type_summary(this->get_type_summary());
     return e;


### PR DESCRIPTION
bugfix: error while copying ast_builtin when used inside an argminmax_assign causing compiler to segfault
