### PR TITLE
Update gm_edge_list_graph_reader.cc

### DIFF
--- a/apps/output_cpp/gm_graph/src/gm_edge_list_graph_reader.cc
+++ b/apps/output_cpp/gm_graph/src/gm_edge_list_graph_reader.cc
@@ -80,7 +80,7 @@ void gm_edge_list_graph_reader::builtGraph() {
     inputFileStream.close();
     G.freeze();
 
-    assert(false); // okay this doen't work. nodeId != nodeIdx
+    //assert(false); // okay this doen't work. nodeId != nodeIdx
     G.do_semi_sort();
     G.make_reverse_edges();
 }


### PR DESCRIPTION
Removed unconditional assert(false) in builtGraph method, which prevented creation of binary graph format from edge list.
