### PR TITLE
Fix to compilation and warnings on ubuntu 18.04

### DIFF
--- a/apps/output_cpp/gm_graph/src/graph_gen_main.cc
+++ b/apps/output_cpp/gm_graph/src/graph_gen_main.cc
@@ -24,11 +24,11 @@ int main(int argc, char** argv) {
         exit(0);
     }
 
-    node_t N = (node_t) atoll(argv[1]);
-    edge_t M = (edge_t) atoll(argv[2]);
+    node_t N = (node_t) strtoull(argv[1], NULL, 10);
+    edge_t M = (edge_t) strtoull(argv[2], NULL, 10);
     int gtype = atoi(argv[4]);
     if (N == 0) {printf("Empty graph not allowed\n"); return EXIT_FAILURE;}
-    printf("Creating Graph, N = %I64d, M = %I64d , Type = %d\n", (int64_t)N, (int64_t) M, gtype);
+    printf("Creating Graph, N = %" PRIi64 ", M = %" PRIi64 " , Type = %d\n", (int64_t)N, (int64_t)M, gtype);
 
 
     gm_graph* g;

--- a/src/common/gm_error.cc
+++ b/src/common/gm_error.cc
@@ -33,11 +33,11 @@ void gm_print_error_header() {
     need_print = false;
 }
 
-void gm_type_error(int errno, ast_id* id, const char* str1, const char* str2) {
+void gm_type_error(int errnumber, ast_id* id, const char* str1, const char* str2) {
     gm_print_error_header();
     if (curr_file != NULL) printf("%s:", curr_file);
     printf("%d: %d: error: ", id->get_line(), id->get_col());
-    switch (errno) {
+    switch (errnumber) {
         case GM_ERROR_INVALID_ITERATOR_FOR_RARROW:
             printf("%s cannot be used in Edge() syntax.\n", id->get_orgname());
             break;
@@ -89,12 +89,12 @@ void gm_type_error(int errno, ast_id* id, const char* str1, const char* str2) {
             break;
     }
 }
-void gm_type_error(int errno, int l, int c, const char* str1, const char* str2, const char* str3) {
+void gm_type_error(int errnumber, int l, int c, const char* str1, const char* str2, const char* str3) {
     gm_print_error_header();
 
     if (curr_file != NULL) printf("%s:", curr_file);
     printf("%d: %d: error: ", l, c);
-    switch (errno) {
+    switch (errnumber) {
         case GM_ERROR_PAR_RETURN:
             printf("return inside parallel consistency\n");
             break;
@@ -196,11 +196,11 @@ void gm_type_error(int errno, int l, int c, const char* str1, const char* str2, 
     }
 }
 
-void gm_type_error(int errno, ast_id* id1, ast_id* id2) {
+void gm_type_error(int errnumber, ast_id* id1, ast_id* id2) {
     gm_print_error_header();
     if (curr_file != NULL) printf("%s:", curr_file);
     printf("%d: %d: error: ", id1->get_line(), id1->get_col());
-    switch (errno) {
+    switch (errnumber) {
         case GM_ERROR_NONGRAPH_TARGET:
             printf("%s is not a graph type object\n", id1->get_orgname());
             break;
@@ -234,7 +234,7 @@ void gm_type_error(int errno, ast_id* id1, ast_id* id2) {
     }
 }
 
-void gm_conf_error(int errno, gm_symtab_entry* target, ast_id* ev1, ast_id* ev2, bool is_warning) {
+void gm_conf_error(int errnumber, gm_symtab_entry* target, ast_id* ev1, ast_id* ev2, bool is_warning) {
     gm_print_error_header();
     if (curr_file != NULL) printf("%s:", curr_file);
 
@@ -246,7 +246,7 @@ void gm_conf_error(int errno, gm_symtab_entry* target, ast_id* ev1, ast_id* ev2,
     ast_id* target_id = target->getId();
     char* name = target_id->get_orgname();
 
-    switch (errno) {
+    switch (errnumber) {
         case GM_ERROR_READ_WRITE_CONFLICT:
             printf("Property %s may have read-write conflict: read at line:%d, write at line:%d\n", name, ev1->get_line(), ev2->get_line());
             break;
@@ -277,10 +277,10 @@ void gm_conf_error(int errno, gm_symtab_entry* target, ast_id* ev1, ast_id* ev2,
 }
 
 // todo: should be differend error routines for different back-ends
-void gm_backend_error(int errno, const char* str1, const char* str2) {
+void gm_backend_error(int errnumber, const char* str1, const char* str2) {
     gm_print_error_header();
     if (curr_file != NULL) printf("%s:", curr_file);
-    switch (errno) {
+    switch (errnumber) {
         case GM_ERROR_FILEWRITE_ERROR:
             printf("cannot open file %s for write\n", str1);
             break;
@@ -302,11 +302,11 @@ void gm_backend_error(int errno, const char* str1, const char* str2) {
             break;
     }
 }
-void gm_backend_error(int errno, int l, int c, const char* str1) {
+void gm_backend_error(int errnumber, int l, int c, const char* str1) {
     gm_print_error_header();
     if (curr_file != NULL) printf("%s:", curr_file);
     printf("%d: %d: error: ", l, c);
-    switch (errno) {
+    switch (errnumber) {
         case GM_ERROR_GPS_EDGE_SEND_VERSIONS:
             printf("Communicating multiple versions of edge value in one message: %s\n", str1);
             break;

--- a/src/inc/gm_builtin.h
+++ b/src/inc/gm_builtin.h
@@ -4,7 +4,7 @@
 #include <list>
 #include <map>
 
-#define AUX_INFO(X,Y)			TO_STR(X)":"TO_STR(Y)
+#define AUX_INFO(X,Y)			TO_STR(X) ":" TO_STR(Y)
 
 #define GM_BLTIN_MUTATE_GROW 1
 #define GM_BLTIN_MUTATE_SHRINK 2

--- a/src/parse/gm_grammer.output
+++ b/src/parse/gm_grammer.output
@@ -25,7 +25,7 @@ Grammar
 
     0 $accept: prog $end
 
-    1 prog: /* empty */
+    1 prog: %empty
     2     | prog proc_def
 
     3 proc_def: proc_head proc_body
@@ -36,7 +36,7 @@ Grammar
     6 proc_name: T_PROC id
     7          | T_LOCAL id
 
-    8 arg_declist1: /* empty */
+    8 arg_declist1: %empty
     9             | arg_declist
 
    10 arg_declist: arg_decl
@@ -45,7 +45,7 @@ Grammar
    12 arg_declist2: arg_decl
    13             | arg_declist2 ',' arg_decl
 
-   14 proc_return_opt: /* empty */
+   14 proc_return_opt: %empty
    15                | proc_return
 
    16 proc_return: ':' prim_type
@@ -120,7 +120,7 @@ Grammar
 
    68 sb_end: '}'
 
-   69 sent_list: /* empty */
+   69 sent_list: %empty
    70          | sent_list sent
 
    71 sent: sent_assignment ';'
@@ -154,11 +154,11 @@ Grammar
    93 foreach_src: id foreach_dir
    94            | field foreach_dir
 
-   95 foreach_dir: /* empty */
+   95 foreach_dir: %empty
    96            | '-'
    97            | '+'
 
-   98 foreach_filter: /* empty */
+   98 foreach_filter: %empty
    99               | '(' bool_expr ')'
 
   100 iterator1: T_NODES
@@ -174,23 +174,23 @@ Grammar
 
   109 sent_bfs: T_BFS bfs_header_format bfs_filters sent_block bfs_reverse
 
-  110 dfs_post: /* empty */
+  110 dfs_post: %empty
   111         | T_POST bfs_filter sent_block
   112         | T_POST sent_block
 
-  113 bfs_reverse: /* empty */
+  113 bfs_reverse: %empty
   114            | T_BACK bfs_filter sent_block
   115            | T_BACK sent_block
 
   116 bfs_header_format: '(' id ':' id opt_tp '.' T_NODES from_or_semi id ')'
 
-  117 opt_tp: /* empty */
+  117 opt_tp: %empty
   118       | '^'
 
   119 from_or_semi: T_FROM
   120             | ';'
 
-  121 bfs_filters: /* empty */
+  121 bfs_filters: %empty
   122            | bfs_navigator
   123            | bfs_filter
   124            | bfs_navigator bfs_filter
@@ -215,7 +215,7 @@ Grammar
 
   136 sent_argminmax_assignment: lhs_list2 minmax_eq rhs_list2 optional_bind
 
-  137 optional_bind: /* empty */
+  137 optional_bind: %empty
   138              | '@' id
 
   139 reduce_eq: T_PLUSEQ
@@ -316,7 +316,7 @@ Grammar
 
   215 rhs_list2: '<' expr ';' expr_list '>'
 
-  216 $@1: /* empty */
+  216 $@1: %empty
 
   217 expr_user: '[' $@1 USER_TEXT ']'
 
@@ -597,7 +597,7 @@ id (178)
     63 64 92 93 107 116 129 138 203 204 205 206 207 208 209
 
 
-state 0
+State 0
 
     0 $accept: . prog $end
 
@@ -606,7 +606,7 @@ state 0
     prog  go to state 1
 
 
-state 1
+State 1
 
     0 $accept: prog . $end
     2 prog: prog . proc_def
@@ -620,14 +620,14 @@ state 1
     proc_name  go to state 7
 
 
-state 2
+State 2
 
     0 $accept: prog $end .
 
     $default  accept
 
 
-state 3
+State 3
 
     6 proc_name: T_PROC . id
 
@@ -636,7 +636,7 @@ state 3
     id  go to state 9
 
 
-state 4
+State 4
 
     7 proc_name: T_LOCAL . id
 
@@ -645,14 +645,14 @@ state 4
     id  go to state 10
 
 
-state 5
+State 5
 
     2 prog: prog proc_def .
 
     $default  reduce using rule 2 (prog)
 
 
-state 6
+State 6
 
     3 proc_def: proc_head . proc_body
 
@@ -663,7 +663,7 @@ state 6
     sb_begin    go to state 14
 
 
-state 7
+State 7
 
     4 proc_head: proc_name . '(' arg_declist1 ')' proc_return_opt
     5          | proc_name . '(' arg_declist1 ';' arg_declist2 ')' proc_return_opt
@@ -671,49 +671,49 @@ state 7
     '('  shift, and go to state 15
 
 
-state 8
+State 8
 
   218 id: ID .
 
     $default  reduce using rule 218 (id)
 
 
-state 9
+State 9
 
     6 proc_name: T_PROC id .
 
     $default  reduce using rule 6 (proc_name)
 
 
-state 10
+State 10
 
     7 proc_name: T_LOCAL id .
 
     $default  reduce using rule 7 (proc_name)
 
 
-state 11
+State 11
 
    67 sb_begin: '{' .
 
     $default  reduce using rule 67 (sb_begin)
 
 
-state 12
+State 12
 
     3 proc_def: proc_head proc_body .
 
     $default  reduce using rule 3 (proc_def)
 
 
-state 13
+State 13
 
    65 proc_body: sent_block .
 
     $default  reduce using rule 65 (proc_body)
 
 
-state 14
+State 14
 
    66 sent_block: sb_begin . sent_list sb_end
 
@@ -722,7 +722,7 @@ state 14
     sent_list  go to state 16
 
 
-state 15
+State 15
 
     4 proc_head: proc_name '(' . arg_declist1 ')' proc_return_opt
     5          | proc_name '(' . arg_declist1 ';' arg_declist2 ')' proc_return_opt
@@ -739,7 +739,7 @@ state 15
     id             go to state 22
 
 
-state 16
+State 16
 
    66 sent_block: sb_begin sent_list . sb_end
    70 sent_list: sent_list . sent
@@ -811,7 +811,7 @@ state 16
     id                         go to state 83
 
 
-state 17
+State 17
 
     4 proc_head: proc_name '(' arg_declist1 . ')' proc_return_opt
     5          | proc_name '(' arg_declist1 . ';' arg_declist2 ')' proc_return_opt
@@ -820,7 +820,7 @@ state 17
     ';'  shift, and go to state 85
 
 
-state 18
+State 18
 
     9 arg_declist1: arg_declist .
    11 arg_declist: arg_declist . ',' arg_decl
@@ -830,21 +830,21 @@ state 18
     $default  reduce using rule 9 (arg_declist1)
 
 
-state 19
+State 19
 
    10 arg_declist: arg_decl .
 
     $default  reduce using rule 10 (arg_declist)
 
 
-state 20
+State 20
 
    18 arg_decl: arg_target . ':' typedecl
 
     ':'  shift, and go to state 87
 
 
-state 21
+State 21
 
    19 arg_target: id_comma_list .
    64 id_comma_list: id_comma_list . ',' id
@@ -854,21 +854,21 @@ state 21
     $default  reduce using rule 19 (arg_target)
 
 
-state 22
+State 22
 
    63 id_comma_list: id .
 
     $default  reduce using rule 63 (id_comma_list)
 
 
-state 23
+State 23
 
    26 graph_type: T_GRAPH .
 
     $default  reduce using rule 26 (graph_type)
 
 
-state 24
+State 24
 
    34 node_type: T_NODE . '(' id ')'
    35          | T_NODE .
@@ -878,7 +878,7 @@ state 24
     $default  reduce using rule 35 (node_type)
 
 
-state 25
+State 25
 
    51 property: T_NODEPROP . '<' prim_type '>' '(' id ')'
    52         | T_NODEPROP . '<' nodeedge_type '>' '(' id ')'
@@ -890,7 +890,7 @@ state 25
     '<'  shift, and go to state 90
 
 
-state 26
+State 26
 
    36 edge_type: T_EDGE . '(' id ')'
    37          | T_EDGE .
@@ -901,7 +901,7 @@ state 26
     $default  reduce using rule 37 (edge_type)
 
 
-state 27
+State 27
 
    57 property: T_EDGEPROP . '<' prim_type '>' '(' id ')'
    58         | T_EDGEPROP . '<' nodeedge_type '>' '(' id ')'
@@ -913,7 +913,7 @@ state 27
     '<'  shift, and go to state 92
 
 
-state 28
+State 28
 
    38 set_type: T_NSET . '(' id ')'
    39         | T_NSET .
@@ -923,7 +923,7 @@ state 28
     $default  reduce using rule 39 (set_type)
 
 
-state 29
+State 29
 
    42 set_type: T_NORDER . '(' id ')'
    43         | T_NORDER .
@@ -933,7 +933,7 @@ state 29
     $default  reduce using rule 43 (set_type)
 
 
-state 30
+State 30
 
    40 set_type: T_NSEQ . '(' id ')'
    41         | T_NSEQ .
@@ -943,7 +943,7 @@ state 30
     $default  reduce using rule 41 (set_type)
 
 
-state 31
+State 31
 
    44 set_type: T_COLLECTION . '<' set_type '>' '(' id ')'
    45         | T_COLLECTION . '<' set_type '>'
@@ -951,14 +951,14 @@ state 31
     '<'  shift, and go to state 96
 
 
-state 32
+State 32
 
    50 map_type: T_MAP . '<' key_type ',' value_type '>'
 
     '<'  shift, and go to state 97
 
 
-state 33
+State 33
 
   108 sent_dfs: T_DFS . bfs_header_format bfs_filters sent_block dfs_post
 
@@ -967,42 +967,42 @@ state 33
     bfs_header_format  go to state 99
 
 
-state 34
+State 34
 
    27 prim_type: T_INT .
 
     $default  reduce using rule 27 (prim_type)
 
 
-state 35
+State 35
 
    29 prim_type: T_FLOAT .
 
     $default  reduce using rule 29 (prim_type)
 
 
-state 36
+State 36
 
    31 prim_type: T_BOOL .
 
     $default  reduce using rule 31 (prim_type)
 
 
-state 37
+State 37
 
    30 prim_type: T_DOUBLE .
 
     $default  reduce using rule 30 (prim_type)
 
 
-state 38
+State 38
 
    28 prim_type: T_LONG .
 
     $default  reduce using rule 28 (prim_type)
 
 
-state 39
+State 39
 
   148 sent_return: T_RETURN . expr
   149            | T_RETURN .
@@ -1043,7 +1043,7 @@ state 39
     id          go to state 83
 
 
-state 40
+State 40
 
   109 sent_bfs: T_BFS . bfs_header_format bfs_filters sent_block bfs_reverse
 
@@ -1052,7 +1052,7 @@ state 40
     bfs_header_format  go to state 128
 
 
-state 41
+State 41
 
    90 sent_foreach: T_FOREACH . foreach_header foreach_filter sent
 
@@ -1061,7 +1061,7 @@ state 41
     foreach_header  go to state 130
 
 
-state 42
+State 42
 
    91 sent_foreach: T_FOR . foreach_header foreach_filter sent
 
@@ -1070,7 +1070,7 @@ state 42
     foreach_header  go to state 131
 
 
-state 43
+State 43
 
   150 sent_if: T_IF . '(' bool_expr ')' sent
   151        | T_IF . '(' bool_expr ')' sent T_ELSE sent
@@ -1078,7 +1078,7 @@ state 43
     '('  shift, and go to state 132
 
 
-state 44
+State 44
 
    89 sent_do_while: T_DO . sent_block T_WHILE '(' bool_expr ')'
 
@@ -1088,14 +1088,14 @@ state 44
     sb_begin    go to state 14
 
 
-state 45
+State 45
 
    88 sent_while: T_WHILE . '(' bool_expr ')' sent_block
 
     '('  shift, and go to state 134
 
 
-state 46
+State 46
 
   214 lhs_list2: '<' . lhs ';' lhs_list '>'
 
@@ -1109,21 +1109,21 @@ state 46
     id          go to state 137
 
 
-state 47
+State 47
 
    86 sent: ';' .
 
     $default  reduce using rule 86 (sent)
 
 
-state 48
+State 48
 
    68 sb_end: '}' .
 
     $default  reduce using rule 68 (sb_end)
 
 
-state 49
+State 49
 
   217 expr_user: '[' . $@1 USER_TEXT ']'
 
@@ -1132,7 +1132,7 @@ state 49
     $@1  go to state 138
 
 
-state 50
+State 50
 
   128 sent_variable_decl: typedecl . var_target
   129                   | typedecl . id '=' rhs
@@ -1144,182 +1144,182 @@ state 50
     id             go to state 141
 
 
-state 51
+State 51
 
    21 typedecl: graph_type .
 
     $default  reduce using rule 21 (typedecl)
 
 
-state 52
+State 52
 
    20 typedecl: prim_type .
 
     $default  reduce using rule 20 (typedecl)
 
 
-state 53
+State 53
 
    23 typedecl: nodeedge_type .
 
     $default  reduce using rule 23 (typedecl)
 
 
-state 54
+State 54
 
    32 nodeedge_type: node_type .
 
     $default  reduce using rule 32 (nodeedge_type)
 
 
-state 55
+State 55
 
    33 nodeedge_type: edge_type .
 
     $default  reduce using rule 33 (nodeedge_type)
 
 
-state 56
+State 56
 
    24 typedecl: set_type .
 
     $default  reduce using rule 24 (typedecl)
 
 
-state 57
+State 57
 
    25 typedecl: map_type .
 
     $default  reduce using rule 25 (typedecl)
 
 
-state 58
+State 58
 
    22 typedecl: property .
 
     $default  reduce using rule 22 (typedecl)
 
 
-state 59
+State 59
 
    73 sent: sent_block .
 
     $default  reduce using rule 73 (sent)
 
 
-state 60
+State 60
 
    66 sent_block: sb_begin sent_list sb_end .
 
     $default  reduce using rule 66 (sent_block)
 
 
-state 61
+State 61
 
    70 sent_list: sent_list sent .
 
     $default  reduce using rule 70 (sent_list)
 
 
-state 62
+State 62
 
    83 sent: sent_call . ';'
 
     ';'  shift, and go to state 142
 
 
-state 63
+State 63
 
    79 sent: sent_while .
 
     $default  reduce using rule 79 (sent)
 
 
-state 64
+State 64
 
    78 sent: sent_do_while . ';'
 
     ';'  shift, and go to state 143
 
 
-state 65
+State 65
 
    74 sent: sent_foreach .
 
     $default  reduce using rule 74 (sent)
 
 
-state 66
+State 66
 
    82 sent: sent_dfs .
 
     $default  reduce using rule 82 (sent)
 
 
-state 67
+State 67
 
    81 sent: sent_bfs .
 
     $default  reduce using rule 81 (sent)
 
 
-state 68
+State 68
 
    72 sent: sent_variable_decl . ';'
 
     ';'  shift, and go to state 144
 
 
-state 69
+State 69
 
    71 sent: sent_assignment . ';'
 
     ';'  shift, and go to state 145
 
 
-state 70
+State 70
 
    76 sent: sent_reduce_assignment . ';'
 
     ';'  shift, and go to state 146
 
 
-state 71
+State 71
 
    77 sent: sent_defer_assignment . ';'
 
     ';'  shift, and go to state 147
 
 
-state 72
+State 72
 
    85 sent: sent_argminmax_assignment . ';'
 
     ';'  shift, and go to state 148
 
 
-state 73
+State 73
 
    80 sent: sent_return . ';'
 
     ';'  shift, and go to state 149
 
 
-state 74
+State 74
 
    75 sent: sent_if .
 
     $default  reduce using rule 75 (sent)
 
 
-state 75
+State 75
 
    84 sent: sent_user . ';'
 
     ';'  shift, and go to state 150
 
 
-state 76
+State 76
 
   131 sent_assignment: lhs . '=' rhs
   132 sent_reduce_assignment: lhs . reduce_eq rhs optional_bind
@@ -1341,14 +1341,14 @@ state 76
     reduce_eq  go to state 161
 
 
-state 77
+State 77
 
   198 lhs: scala .
 
     $default  reduce using rule 198 (lhs)
 
 
-state 78
+State 78
 
   199 lhs: field .
   209 built_in: field . '.' id arg_list
@@ -1358,21 +1358,21 @@ state 78
     $default  reduce using rule 199 (lhs)
 
 
-state 79
+State 79
 
   200 lhs: map_access .
 
     $default  reduce using rule 200 (lhs)
 
 
-state 80
+State 80
 
    87 sent_call: built_in .
 
     $default  reduce using rule 87 (sent_call)
 
 
-state 81
+State 81
 
   136 sent_argminmax_assignment: lhs_list2 . minmax_eq rhs_list2 optional_bind
 
@@ -1382,7 +1382,7 @@ state 81
     minmax_eq  go to state 165
 
 
-state 82
+State 82
 
   152 sent_user: expr_user .
   153          | expr_user . T_DOUBLE_COLON '[' lhs_list ']'
@@ -1392,7 +1392,7 @@ state 82
     $default  reduce using rule 152 (sent_user)
 
 
-state 83
+State 83
 
   203 scala: id .
   204 field: id . '.' id
@@ -1409,7 +1409,7 @@ state 83
     arg_list  go to state 170
 
 
-state 84
+State 84
 
     4 proc_head: proc_name '(' arg_declist1 ')' . proc_return_opt
 
@@ -1421,7 +1421,7 @@ state 84
     proc_return      go to state 173
 
 
-state 85
+State 85
 
     5 proc_head: proc_name '(' arg_declist1 ';' . arg_declist2 ')' proc_return_opt
 
@@ -1434,7 +1434,7 @@ state 85
     id             go to state 22
 
 
-state 86
+State 86
 
    11 arg_declist: arg_declist ',' . arg_decl
 
@@ -1446,7 +1446,7 @@ state 86
     id             go to state 22
 
 
-state 87
+State 87
 
    18 arg_decl: arg_target ':' . typedecl
 
@@ -1477,7 +1477,7 @@ state 87
     property       go to state 58
 
 
-state 88
+State 88
 
    64 id_comma_list: id_comma_list ',' . id
 
@@ -1486,7 +1486,7 @@ state 88
     id  go to state 179
 
 
-state 89
+State 89
 
    34 node_type: T_NODE '(' . id ')'
 
@@ -1495,7 +1495,7 @@ state 89
     id  go to state 180
 
 
-state 90
+State 90
 
    51 property: T_NODEPROP '<' . prim_type '>' '(' id ')'
    52         | T_NODEPROP '<' . nodeedge_type '>' '(' id ')'
@@ -1523,7 +1523,7 @@ state 90
     set_type       go to state 183
 
 
-state 91
+State 91
 
    36 edge_type: T_EDGE '(' . id ')'
   205 field: T_EDGE '(' . id ')' '.' id
@@ -1533,7 +1533,7 @@ state 91
     id  go to state 184
 
 
-state 92
+State 92
 
    57 property: T_EDGEPROP '<' . prim_type '>' '(' id ')'
    58         | T_EDGEPROP '<' . nodeedge_type '>' '(' id ')'
@@ -1561,7 +1561,7 @@ state 92
     set_type       go to state 187
 
 
-state 93
+State 93
 
    38 set_type: T_NSET '(' . id ')'
 
@@ -1570,7 +1570,7 @@ state 93
     id  go to state 188
 
 
-state 94
+State 94
 
    42 set_type: T_NORDER '(' . id ')'
 
@@ -1579,7 +1579,7 @@ state 94
     id  go to state 189
 
 
-state 95
+State 95
 
    40 set_type: T_NSEQ '(' . id ')'
 
@@ -1588,7 +1588,7 @@ state 95
     id  go to state 190
 
 
-state 96
+State 96
 
    44 set_type: T_COLLECTION '<' . set_type '>' '(' id ')'
    45         | T_COLLECTION '<' . set_type '>'
@@ -1601,7 +1601,7 @@ state 96
     set_type  go to state 191
 
 
-state 97
+State 97
 
    50 map_type: T_MAP '<' . key_type ',' value_type '>'
 
@@ -1620,7 +1620,7 @@ state 97
     key_type       go to state 194
 
 
-state 98
+State 98
 
   116 bfs_header_format: '(' . id ':' id opt_tp '.' T_NODES from_or_semi id ')'
 
@@ -1629,7 +1629,7 @@ state 98
     id  go to state 195
 
 
-state 99
+State 99
 
   108 sent_dfs: T_DFS bfs_header_format . bfs_filters sent_block dfs_post
 
@@ -1643,112 +1643,112 @@ state 99
     bfs_filter     go to state 200
 
 
-state 100
+State 100
 
   205 field: T_EDGE . '(' id ')' '.' id
 
     '('  shift, and go to state 201
 
 
-state 101
+State 101
 
   188 reduce_op: T_SUM .
 
     $default  reduce using rule 188 (reduce_op)
 
 
-state 102
+State 102
 
   189 reduce_op: T_PRODUCT .
 
     $default  reduce using rule 189 (reduce_op)
 
 
-state 103
+State 103
 
   190 reduce_op: T_MIN .
 
     $default  reduce using rule 190 (reduce_op)
 
 
-state 104
+State 104
 
   191 reduce_op: T_MAX .
 
     $default  reduce using rule 191 (reduce_op)
 
 
-state 105
+State 105
 
   195 reduce_op2: T_COUNT .
 
     $default  reduce using rule 195 (reduce_op2)
 
 
-state 106
+State 106
 
   193 reduce_op: T_ALL .
 
     $default  reduce using rule 193 (reduce_op)
 
 
-state 107
+State 107
 
   192 reduce_op: T_EXIST .
 
     $default  reduce using rule 192 (reduce_op)
 
 
-state 108
+State 108
 
   194 reduce_op: T_AVG .
 
     $default  reduce using rule 194 (reduce_op)
 
 
-state 109
+State 109
 
   197 inf: T_M_INF .
 
     $default  reduce using rule 197 (inf)
 
 
-state 110
+State 110
 
   196 inf: T_P_INF .
 
     $default  reduce using rule 196 (inf)
 
 
-state 111
+State 111
 
   181 expr: T_NIL .
 
     $default  reduce using rule 181 (expr)
 
 
-state 112
+State 112
 
   178 expr: INT_NUM .
 
     $default  reduce using rule 178 (expr)
 
 
-state 113
+State 113
 
   179 expr: FLOAT_NUM .
 
     $default  reduce using rule 179 (expr)
 
 
-state 114
+State 114
 
   177 expr: BOOL_VAL .
 
     $default  reduce using rule 177 (expr)
 
 
-state 115
+State 115
 
   156 expr: '-' . expr
 
@@ -1786,7 +1786,7 @@ state 115
     id          go to state 83
 
 
-state 116
+State 116
 
   154 expr: '(' . expr ')'
   158     | '(' . prim_type ')' expr
@@ -1831,7 +1831,7 @@ state 116
     id          go to state 83
 
 
-state 117
+State 117
 
   155 expr: '|' . expr '|'
 
@@ -1869,7 +1869,7 @@ state 117
     id          go to state 83
 
 
-state 118
+State 118
 
   157 expr: '!' . expr
 
@@ -1907,7 +1907,7 @@ state 118
     id          go to state 83
 
 
-state 119
+State 119
 
   148 sent_return: T_RETURN expr .
   163 expr: expr . '%' expr
@@ -1943,7 +1943,7 @@ state 119
     $default  reduce using rule 148 (sent_return)
 
 
-state 120
+State 120
 
   159 expr: reduce_op . foreach_header '(' expr ')' '{' expr '}'
   160     | reduce_op . foreach_header '{' expr '}'
@@ -1953,7 +1953,7 @@ state 120
     foreach_header  go to state 221
 
 
-state 121
+State 121
 
   161 expr: reduce_op2 . foreach_header '(' expr ')'
   162     | reduce_op2 . foreach_header
@@ -1963,21 +1963,21 @@ state 121
     foreach_header  go to state 222
 
 
-state 122
+State 122
 
   180 expr: inf .
 
     $default  reduce using rule 180 (expr)
 
 
-state 123
+State 123
 
   182 expr: scala .
 
     $default  reduce using rule 182 (expr)
 
 
-state 124
+State 124
 
   183 expr: field .
   209 built_in: field . '.' id arg_list
@@ -1987,28 +1987,28 @@ state 124
     $default  reduce using rule 183 (expr)
 
 
-state 125
+State 125
 
   186 expr: map_access .
 
     $default  reduce using rule 186 (expr)
 
 
-state 126
+State 126
 
   184 expr: built_in .
 
     $default  reduce using rule 184 (expr)
 
 
-state 127
+State 127
 
   185 expr: expr_user .
 
     $default  reduce using rule 185 (expr)
 
 
-state 128
+State 128
 
   109 sent_bfs: T_BFS bfs_header_format . bfs_filters sent_block bfs_reverse
 
@@ -2022,7 +2022,7 @@ state 128
     bfs_filter     go to state 200
 
 
-state 129
+State 129
 
    92 foreach_header: '(' . id ':' foreach_src '.' iterator1 ')'
 
@@ -2031,7 +2031,7 @@ state 129
     id  go to state 224
 
 
-state 130
+State 130
 
    90 sent_foreach: T_FOREACH foreach_header . foreach_filter sent
 
@@ -2042,7 +2042,7 @@ state 130
     foreach_filter  go to state 226
 
 
-state 131
+State 131
 
    91 sent_foreach: T_FOR foreach_header . foreach_filter sent
 
@@ -2053,7 +2053,7 @@ state 131
     foreach_filter  go to state 227
 
 
-state 132
+State 132
 
   150 sent_if: T_IF '(' . bool_expr ')' sent
   151        | T_IF '(' . bool_expr ')' sent T_ELSE sent
@@ -2093,14 +2093,14 @@ state 132
     id          go to state 83
 
 
-state 133
+State 133
 
    89 sent_do_while: T_DO sent_block . T_WHILE '(' bool_expr ')'
 
     T_WHILE  shift, and go to state 230
 
 
-state 134
+State 134
 
    88 sent_while: T_WHILE '(' . bool_expr ')' sent_block
 
@@ -2139,21 +2139,21 @@ state 134
     id          go to state 83
 
 
-state 135
+State 135
 
   214 lhs_list2: '<' lhs . ';' lhs_list '>'
 
     ';'  shift, and go to state 232
 
 
-state 136
+State 136
 
   199 lhs: field .
 
     $default  reduce using rule 199 (lhs)
 
 
-state 137
+State 137
 
   203 scala: id .
   204 field: id . '.' id
@@ -2165,14 +2165,14 @@ state 137
     $default  reduce using rule 203 (scala)
 
 
-state 138
+State 138
 
   217 expr_user: '[' $@1 . USER_TEXT ']'
 
     USER_TEXT  shift, and go to state 234
 
 
-state 139
+State 139
 
    64 id_comma_list: id_comma_list . ',' id
   130 var_target: id_comma_list .
@@ -2182,14 +2182,14 @@ state 139
     $default  reduce using rule 130 (var_target)
 
 
-state 140
+State 140
 
   128 sent_variable_decl: typedecl var_target .
 
     $default  reduce using rule 128 (sent_variable_decl)
 
 
-state 141
+State 141
 
    63 id_comma_list: id .
   129 sent_variable_decl: typedecl id . '=' rhs
@@ -2199,70 +2199,70 @@ state 141
     $default  reduce using rule 63 (id_comma_list)
 
 
-state 142
+State 142
 
    83 sent: sent_call ';' .
 
     $default  reduce using rule 83 (sent)
 
 
-state 143
+State 143
 
    78 sent: sent_do_while ';' .
 
     $default  reduce using rule 78 (sent)
 
 
-state 144
+State 144
 
    72 sent: sent_variable_decl ';' .
 
     $default  reduce using rule 72 (sent)
 
 
-state 145
+State 145
 
    71 sent: sent_assignment ';' .
 
     $default  reduce using rule 71 (sent)
 
 
-state 146
+State 146
 
    76 sent: sent_reduce_assignment ';' .
 
     $default  reduce using rule 76 (sent)
 
 
-state 147
+State 147
 
    77 sent: sent_defer_assignment ';' .
 
     $default  reduce using rule 77 (sent)
 
 
-state 148
+State 148
 
    85 sent: sent_argminmax_assignment ';' .
 
     $default  reduce using rule 85 (sent)
 
 
-state 149
+State 149
 
    80 sent: sent_return ';' .
 
     $default  reduce using rule 80 (sent)
 
 
-state 150
+State 150
 
    84 sent: sent_user ';' .
 
     $default  reduce using rule 84 (sent)
 
 
-state 151
+State 151
 
   135 sent_defer_assignment: lhs T_LE . rhs optional_bind
 
@@ -2301,35 +2301,35 @@ state 151
     id          go to state 83
 
 
-state 152
+State 152
 
   139 reduce_eq: T_PLUSEQ .
 
     $default  reduce using rule 139 (reduce_eq)
 
 
-state 153
+State 153
 
   140 reduce_eq: T_MULTEQ .
 
     $default  reduce using rule 140 (reduce_eq)
 
 
-state 154
+State 154
 
   141 reduce_eq: T_MINEQ .
 
     $default  reduce using rule 141 (reduce_eq)
 
 
-state 155
+State 155
 
   142 reduce_eq: T_MAXEQ .
 
     $default  reduce using rule 142 (reduce_eq)
 
 
-state 156
+State 156
 
   133 sent_reduce_assignment: lhs T_PLUSPLUS . optional_bind
 
@@ -2340,7 +2340,7 @@ state 156
     optional_bind  go to state 239
 
 
-state 157
+State 157
 
   134 sent_reduce_assignment: lhs T_MINUSMINUS . optional_bind
 
@@ -2351,21 +2351,21 @@ state 157
     optional_bind  go to state 240
 
 
-state 158
+State 158
 
   143 reduce_eq: T_ANDEQ .
 
     $default  reduce using rule 143 (reduce_eq)
 
 
-state 159
+State 159
 
   144 reduce_eq: T_OREQ .
 
     $default  reduce using rule 144 (reduce_eq)
 
 
-state 160
+State 160
 
   131 sent_assignment: lhs '=' . rhs
 
@@ -2404,7 +2404,7 @@ state 160
     id          go to state 83
 
 
-state 161
+State 161
 
   132 sent_reduce_assignment: lhs reduce_eq . rhs optional_bind
 
@@ -2443,7 +2443,7 @@ state 161
     id          go to state 83
 
 
-state 162
+State 162
 
   209 built_in: field '.' . id arg_list
 
@@ -2452,21 +2452,21 @@ state 162
     id  go to state 243
 
 
-state 163
+State 163
 
   145 minmax_eq: T_MINEQ .
 
     $default  reduce using rule 145 (minmax_eq)
 
 
-state 164
+State 164
 
   146 minmax_eq: T_MAXEQ .
 
     $default  reduce using rule 146 (minmax_eq)
 
 
-state 165
+State 165
 
   136 sent_argminmax_assignment: lhs_list2 minmax_eq . rhs_list2 optional_bind
 
@@ -2475,14 +2475,14 @@ state 165
     rhs_list2  go to state 245
 
 
-state 166
+State 166
 
   153 sent_user: expr_user T_DOUBLE_COLON . '[' lhs_list ']'
 
     '['  shift, and go to state 246
 
 
-state 167
+State 167
 
   210 arg_list: '(' . expr_list ')'
   211         | '(' . ')'
@@ -2523,7 +2523,7 @@ state 167
     id          go to state 83
 
 
-state 168
+State 168
 
   204 field: id '.' . id
   207 built_in: id '.' . id arg_list
@@ -2533,7 +2533,7 @@ state 168
     id  go to state 250
 
 
-state 169
+State 169
 
   206 map_access: id '[' . expr ']'
 
@@ -2571,14 +2571,14 @@ state 169
     id          go to state 83
 
 
-state 170
+State 170
 
   208 built_in: id arg_list .
 
     $default  reduce using rule 208 (built_in)
 
 
-state 171
+State 171
 
    16 proc_return: ':' . prim_type
    17            | ':' . node_type
@@ -2594,21 +2594,21 @@ state 171
     node_type  go to state 253
 
 
-state 172
+State 172
 
     4 proc_head: proc_name '(' arg_declist1 ')' proc_return_opt .
 
     $default  reduce using rule 4 (proc_head)
 
 
-state 173
+State 173
 
    15 proc_return_opt: proc_return .
 
     $default  reduce using rule 15 (proc_return_opt)
 
 
-state 174
+State 174
 
     5 proc_head: proc_name '(' arg_declist1 ';' arg_declist2 . ')' proc_return_opt
    13 arg_declist2: arg_declist2 . ',' arg_decl
@@ -2617,21 +2617,21 @@ state 174
     ','  shift, and go to state 255
 
 
-state 175
+State 175
 
    12 arg_declist2: arg_decl .
 
     $default  reduce using rule 12 (arg_declist2)
 
 
-state 176
+State 176
 
    11 arg_declist: arg_declist ',' arg_decl .
 
     $default  reduce using rule 11 (arg_declist)
 
 
-state 177
+State 177
 
    36 edge_type: T_EDGE . '(' id ')'
    37          | T_EDGE .
@@ -2641,28 +2641,28 @@ state 177
     $default  reduce using rule 37 (edge_type)
 
 
-state 178
+State 178
 
    18 arg_decl: arg_target ':' typedecl .
 
     $default  reduce using rule 18 (arg_decl)
 
 
-state 179
+State 179
 
    64 id_comma_list: id_comma_list ',' id .
 
     $default  reduce using rule 64 (id_comma_list)
 
 
-state 180
+State 180
 
    34 node_type: T_NODE '(' id . ')'
 
     ')'  shift, and go to state 257
 
 
-state 181
+State 181
 
    51 property: T_NODEPROP '<' prim_type . '>' '(' id ')'
    54         | T_NODEPROP '<' prim_type . '>'
@@ -2670,7 +2670,7 @@ state 181
     '>'  shift, and go to state 258
 
 
-state 182
+State 182
 
    52 property: T_NODEPROP '<' nodeedge_type . '>' '(' id ')'
    55         | T_NODEPROP '<' nodeedge_type . '>'
@@ -2678,7 +2678,7 @@ state 182
     '>'  shift, and go to state 259
 
 
-state 183
+State 183
 
    53 property: T_NODEPROP '<' set_type . '>' '(' id ')'
    56         | T_NODEPROP '<' set_type . '>'
@@ -2686,7 +2686,7 @@ state 183
     '>'  shift, and go to state 260
 
 
-state 184
+State 184
 
    36 edge_type: T_EDGE '(' id . ')'
   205 field: T_EDGE '(' id . ')' '.' id
@@ -2694,7 +2694,7 @@ state 184
     ')'  shift, and go to state 261
 
 
-state 185
+State 185
 
    57 property: T_EDGEPROP '<' prim_type . '>' '(' id ')'
    60         | T_EDGEPROP '<' prim_type . '>'
@@ -2702,7 +2702,7 @@ state 185
     '>'  shift, and go to state 262
 
 
-state 186
+State 186
 
    58 property: T_EDGEPROP '<' nodeedge_type . '>' '(' id ')'
    61         | T_EDGEPROP '<' nodeedge_type . '>'
@@ -2710,7 +2710,7 @@ state 186
     '>'  shift, and go to state 263
 
 
-state 187
+State 187
 
    59 property: T_EDGEPROP '<' set_type . '>' '(' id ')'
    62         | T_EDGEPROP '<' set_type . '>'
@@ -2718,28 +2718,28 @@ state 187
     '>'  shift, and go to state 264
 
 
-state 188
+State 188
 
    38 set_type: T_NSET '(' id . ')'
 
     ')'  shift, and go to state 265
 
 
-state 189
+State 189
 
    42 set_type: T_NORDER '(' id . ')'
 
     ')'  shift, and go to state 266
 
 
-state 190
+State 190
 
    40 set_type: T_NSEQ '(' id . ')'
 
     ')'  shift, and go to state 267
 
 
-state 191
+State 191
 
    44 set_type: T_COLLECTION '<' set_type . '>' '(' id ')'
    45         | T_COLLECTION '<' set_type . '>'
@@ -2747,35 +2747,35 @@ state 191
     '>'  shift, and go to state 268
 
 
-state 192
+State 192
 
    47 key_type: prim_type .
 
     $default  reduce using rule 47 (key_type)
 
 
-state 193
+State 193
 
    46 key_type: nodeedge_type .
 
     $default  reduce using rule 46 (key_type)
 
 
-state 194
+State 194
 
    50 map_type: T_MAP '<' key_type . ',' value_type '>'
 
     ','  shift, and go to state 269
 
 
-state 195
+State 195
 
   116 bfs_header_format: '(' id . ':' id opt_tp '.' T_NODES from_or_semi id ')'
 
     ':'  shift, and go to state 270
 
 
-state 196
+State 196
 
   127 bfs_filter: '(' . expr ')'
 
@@ -2813,7 +2813,7 @@ state 196
     id          go to state 83
 
 
-state 197
+State 197
 
   126 bfs_navigator: '[' . expr ']'
 
@@ -2851,7 +2851,7 @@ state 197
     id          go to state 83
 
 
-state 198
+State 198
 
   108 sent_dfs: T_DFS bfs_header_format bfs_filters . sent_block dfs_post
 
@@ -2861,7 +2861,7 @@ state 198
     sb_begin    go to state 14
 
 
-state 199
+State 199
 
   122 bfs_filters: bfs_navigator .
   124            | bfs_navigator . bfs_filter
@@ -2873,7 +2873,7 @@ state 199
     bfs_filter  go to state 274
 
 
-state 200
+State 200
 
   123 bfs_filters: bfs_filter .
   125            | bfs_filter . bfs_navigator
@@ -2885,7 +2885,7 @@ state 200
     bfs_navigator  go to state 275
 
 
-state 201
+State 201
 
   205 field: T_EDGE '(' . id ')' '.' id
 
@@ -2894,7 +2894,7 @@ state 201
     id  go to state 276
 
 
-state 202
+State 202
 
   156 expr: '-' expr .
   163     | expr . '%' expr
@@ -2915,14 +2915,14 @@ state 202
     $default  reduce using rule 156 (expr)
 
 
-state 203
+State 203
 
   158 expr: '(' prim_type . ')' expr
 
     ')'  shift, and go to state 277
 
 
-state 204
+State 204
 
   154 expr: '(' expr . ')'
   163     | expr . '%' expr
@@ -2957,7 +2957,7 @@ state 204
     ')'    shift, and go to state 278
 
 
-state 205
+State 205
 
   155 expr: '|' expr . '|'
   163     | expr . '%' expr
@@ -2992,7 +2992,7 @@ state 205
     '|'    shift, and go to state 279
 
 
-state 206
+State 206
 
   157 expr: '!' expr .
   163     | expr . '%' expr
@@ -3013,7 +3013,7 @@ state 206
     $default  reduce using rule 157 (expr)
 
 
-state 207
+State 207
 
   174 expr: expr T_AND . expr
 
@@ -3051,7 +3051,7 @@ state 207
     id          go to state 83
 
 
-state 208
+State 208
 
   175 expr: expr T_OR . expr
 
@@ -3089,7 +3089,7 @@ state 208
     id          go to state 83
 
 
-state 209
+State 209
 
   172 expr: expr T_EQ . expr
 
@@ -3127,7 +3127,7 @@ state 209
     id          go to state 83
 
 
-state 210
+State 210
 
   173 expr: expr T_NEQ . expr
 
@@ -3165,7 +3165,7 @@ state 210
     id          go to state 83
 
 
-state 211
+State 211
 
   168 expr: expr T_LE . expr
 
@@ -3203,7 +3203,7 @@ state 211
     id          go to state 83
 
 
-state 212
+State 212
 
   169 expr: expr T_GE . expr
 
@@ -3241,7 +3241,7 @@ state 212
     id          go to state 83
 
 
-state 213
+State 213
 
   176 expr: expr '?' . expr ':' expr
 
@@ -3279,7 +3279,7 @@ state 213
     id          go to state 83
 
 
-state 214
+State 214
 
   170 expr: expr '<' . expr
 
@@ -3317,7 +3317,7 @@ state 214
     id          go to state 83
 
 
-state 215
+State 215
 
   171 expr: expr '>' . expr
 
@@ -3355,7 +3355,7 @@ state 215
     id          go to state 83
 
 
-state 216
+State 216
 
   166 expr: expr '+' . expr
 
@@ -3393,7 +3393,7 @@ state 216
     id          go to state 83
 
 
-state 217
+State 217
 
   167 expr: expr '-' . expr
 
@@ -3431,7 +3431,7 @@ state 217
     id          go to state 83
 
 
-state 218
+State 218
 
   164 expr: expr '*' . expr
 
@@ -3469,7 +3469,7 @@ state 218
     id          go to state 83
 
 
-state 219
+State 219
 
   165 expr: expr '/' . expr
 
@@ -3507,7 +3507,7 @@ state 219
     id          go to state 83
 
 
-state 220
+State 220
 
   163 expr: expr '%' . expr
 
@@ -3545,7 +3545,7 @@ state 220
     id          go to state 83
 
 
-state 221
+State 221
 
   159 expr: reduce_op foreach_header . '(' expr ')' '{' expr '}'
   160     | reduce_op foreach_header . '{' expr '}'
@@ -3554,7 +3554,7 @@ state 221
     '{'  shift, and go to state 295
 
 
-state 222
+State 222
 
   161 expr: reduce_op2 foreach_header . '(' expr ')'
   162     | reduce_op2 foreach_header .
@@ -3564,7 +3564,7 @@ state 222
     $default  reduce using rule 162 (expr)
 
 
-state 223
+State 223
 
   109 sent_bfs: T_BFS bfs_header_format bfs_filters . sent_block bfs_reverse
 
@@ -3574,14 +3574,14 @@ state 223
     sb_begin    go to state 14
 
 
-state 224
+State 224
 
    92 foreach_header: '(' id . ':' foreach_src '.' iterator1 ')'
 
     ':'  shift, and go to state 298
 
 
-state 225
+State 225
 
    99 foreach_filter: '(' . bool_expr ')'
 
@@ -3620,7 +3620,7 @@ state 225
     id          go to state 83
 
 
-state 226
+State 226
 
    90 sent_foreach: T_FOREACH foreach_header foreach_filter . sent
 
@@ -3689,7 +3689,7 @@ state 226
     id                         go to state 83
 
 
-state 227
+State 227
 
    91 sent_foreach: T_FOR foreach_header foreach_filter . sent
 
@@ -3758,7 +3758,7 @@ state 227
     id                         go to state 83
 
 
-state 228
+State 228
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -3794,7 +3794,7 @@ state 228
     $default  reduce using rule 187 (bool_expr)
 
 
-state 229
+State 229
 
   150 sent_if: T_IF '(' bool_expr . ')' sent
   151        | T_IF '(' bool_expr . ')' sent T_ELSE sent
@@ -3802,21 +3802,21 @@ state 229
     ')'  shift, and go to state 302
 
 
-state 230
+State 230
 
    89 sent_do_while: T_DO sent_block T_WHILE . '(' bool_expr ')'
 
     '('  shift, and go to state 303
 
 
-state 231
+State 231
 
    88 sent_while: T_WHILE '(' bool_expr . ')' sent_block
 
     ')'  shift, and go to state 304
 
 
-state 232
+State 232
 
   214 lhs_list2: '<' lhs ';' . lhs_list '>'
 
@@ -3831,7 +3831,7 @@ state 232
     id          go to state 137
 
 
-state 233
+State 233
 
   204 field: id '.' . id
 
@@ -3840,14 +3840,14 @@ state 233
     id  go to state 307
 
 
-state 234
+State 234
 
   217 expr_user: '[' $@1 USER_TEXT . ']'
 
     ']'  shift, and go to state 308
 
 
-state 235
+State 235
 
   129 sent_variable_decl: typedecl id '=' . rhs
 
@@ -3886,7 +3886,7 @@ state 235
     id          go to state 83
 
 
-state 236
+State 236
 
   135 sent_defer_assignment: lhs T_LE rhs . optional_bind
 
@@ -3897,7 +3897,7 @@ state 236
     optional_bind  go to state 310
 
 
-state 237
+State 237
 
   147 rhs: expr .
   163 expr: expr . '%' expr
@@ -3933,7 +3933,7 @@ state 237
     $default  reduce using rule 147 (rhs)
 
 
-state 238
+State 238
 
   138 optional_bind: '@' . id
 
@@ -3942,28 +3942,28 @@ state 238
     id  go to state 311
 
 
-state 239
+State 239
 
   133 sent_reduce_assignment: lhs T_PLUSPLUS optional_bind .
 
     $default  reduce using rule 133 (sent_reduce_assignment)
 
 
-state 240
+State 240
 
   134 sent_reduce_assignment: lhs T_MINUSMINUS optional_bind .
 
     $default  reduce using rule 134 (sent_reduce_assignment)
 
 
-state 241
+State 241
 
   131 sent_assignment: lhs '=' rhs .
 
     $default  reduce using rule 131 (sent_assignment)
 
 
-state 242
+State 242
 
   132 sent_reduce_assignment: lhs reduce_eq rhs . optional_bind
 
@@ -3974,7 +3974,7 @@ state 242
     optional_bind  go to state 312
 
 
-state 243
+State 243
 
   209 built_in: field '.' id . arg_list
 
@@ -3983,7 +3983,7 @@ state 243
     arg_list  go to state 313
 
 
-state 244
+State 244
 
   215 rhs_list2: '<' . expr ';' expr_list '>'
 
@@ -4021,7 +4021,7 @@ state 244
     id          go to state 83
 
 
-state 245
+State 245
 
   136 sent_argminmax_assignment: lhs_list2 minmax_eq rhs_list2 . optional_bind
 
@@ -4032,7 +4032,7 @@ state 245
     optional_bind  go to state 315
 
 
-state 246
+State 246
 
   153 sent_user: expr_user T_DOUBLE_COLON '[' . lhs_list ']'
 
@@ -4047,14 +4047,14 @@ state 246
     id          go to state 137
 
 
-state 247
+State 247
 
   211 arg_list: '(' ')' .
 
     $default  reduce using rule 211 (arg_list)
 
 
-state 248
+State 248
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4093,14 +4093,14 @@ state 248
     $default  reduce using rule 212 (expr_list)
 
 
-state 249
+State 249
 
   210 arg_list: '(' expr_list . ')'
 
     ')'  shift, and go to state 318
 
 
-state 250
+State 250
 
   204 field: id '.' id .
   207 built_in: id '.' id . arg_list
@@ -4112,7 +4112,7 @@ state 250
     arg_list  go to state 319
 
 
-state 251
+State 251
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4147,21 +4147,21 @@ state 251
     ']'    shift, and go to state 320
 
 
-state 252
+State 252
 
    16 proc_return: ':' prim_type .
 
     $default  reduce using rule 16 (proc_return)
 
 
-state 253
+State 253
 
    17 proc_return: ':' node_type .
 
     $default  reduce using rule 17 (proc_return)
 
 
-state 254
+State 254
 
     5 proc_head: proc_name '(' arg_declist1 ';' arg_declist2 ')' . proc_return_opt
 
@@ -4173,7 +4173,7 @@ state 254
     proc_return      go to state 173
 
 
-state 255
+State 255
 
    13 arg_declist2: arg_declist2 ',' . arg_decl
 
@@ -4185,7 +4185,7 @@ state 255
     id             go to state 22
 
 
-state 256
+State 256
 
    36 edge_type: T_EDGE '(' . id ')'
 
@@ -4194,14 +4194,14 @@ state 256
     id  go to state 323
 
 
-state 257
+State 257
 
    34 node_type: T_NODE '(' id ')' .
 
     $default  reduce using rule 34 (node_type)
 
 
-state 258
+State 258
 
    51 property: T_NODEPROP '<' prim_type '>' . '(' id ')'
    54         | T_NODEPROP '<' prim_type '>' .
@@ -4211,7 +4211,7 @@ state 258
     $default  reduce using rule 54 (property)
 
 
-state 259
+State 259
 
    52 property: T_NODEPROP '<' nodeedge_type '>' . '(' id ')'
    55         | T_NODEPROP '<' nodeedge_type '>' .
@@ -4221,7 +4221,7 @@ state 259
     $default  reduce using rule 55 (property)
 
 
-state 260
+State 260
 
    53 property: T_NODEPROP '<' set_type '>' . '(' id ')'
    56         | T_NODEPROP '<' set_type '>' .
@@ -4231,7 +4231,7 @@ state 260
     $default  reduce using rule 56 (property)
 
 
-state 261
+State 261
 
    36 edge_type: T_EDGE '(' id ')' .
   205 field: T_EDGE '(' id ')' . '.' id
@@ -4241,7 +4241,7 @@ state 261
     $default  reduce using rule 36 (edge_type)
 
 
-state 262
+State 262
 
    57 property: T_EDGEPROP '<' prim_type '>' . '(' id ')'
    60         | T_EDGEPROP '<' prim_type '>' .
@@ -4251,7 +4251,7 @@ state 262
     $default  reduce using rule 60 (property)
 
 
-state 263
+State 263
 
    58 property: T_EDGEPROP '<' nodeedge_type '>' . '(' id ')'
    61         | T_EDGEPROP '<' nodeedge_type '>' .
@@ -4261,7 +4261,7 @@ state 263
     $default  reduce using rule 61 (property)
 
 
-state 264
+State 264
 
    59 property: T_EDGEPROP '<' set_type '>' . '(' id ')'
    62         | T_EDGEPROP '<' set_type '>' .
@@ -4271,28 +4271,28 @@ state 264
     $default  reduce using rule 62 (property)
 
 
-state 265
+State 265
 
    38 set_type: T_NSET '(' id ')' .
 
     $default  reduce using rule 38 (set_type)
 
 
-state 266
+State 266
 
    42 set_type: T_NORDER '(' id ')' .
 
     $default  reduce using rule 42 (set_type)
 
 
-state 267
+State 267
 
    40 set_type: T_NSEQ '(' id ')' .
 
     $default  reduce using rule 40 (set_type)
 
 
-state 268
+State 268
 
    44 set_type: T_COLLECTION '<' set_type '>' . '(' id ')'
    45         | T_COLLECTION '<' set_type '>' .
@@ -4302,7 +4302,7 @@ state 268
     $default  reduce using rule 45 (set_type)
 
 
-state 269
+State 269
 
    50 map_type: T_MAP '<' key_type ',' . value_type '>'
 
@@ -4321,7 +4321,7 @@ state 269
     value_type     go to state 334
 
 
-state 270
+State 270
 
   116 bfs_header_format: '(' id ':' . id opt_tp '.' T_NODES from_or_semi id ')'
 
@@ -4330,7 +4330,7 @@ state 270
     id  go to state 335
 
 
-state 271
+State 271
 
   127 bfs_filter: '(' expr . ')'
   163 expr: expr . '%' expr
@@ -4365,7 +4365,7 @@ state 271
     ')'    shift, and go to state 336
 
 
-state 272
+State 272
 
   126 bfs_navigator: '[' expr . ']'
   163 expr: expr . '%' expr
@@ -4400,7 +4400,7 @@ state 272
     ']'    shift, and go to state 337
 
 
-state 273
+State 273
 
   108 sent_dfs: T_DFS bfs_header_format bfs_filters sent_block . dfs_post
 
@@ -4411,28 +4411,28 @@ state 273
     dfs_post  go to state 339
 
 
-state 274
+State 274
 
   124 bfs_filters: bfs_navigator bfs_filter .
 
     $default  reduce using rule 124 (bfs_filters)
 
 
-state 275
+State 275
 
   125 bfs_filters: bfs_filter bfs_navigator .
 
     $default  reduce using rule 125 (bfs_filters)
 
 
-state 276
+State 276
 
   205 field: T_EDGE '(' id . ')' '.' id
 
     ')'  shift, and go to state 340
 
 
-state 277
+State 277
 
   158 expr: '(' prim_type ')' . expr
 
@@ -4470,21 +4470,21 @@ state 277
     id          go to state 83
 
 
-state 278
+State 278
 
   154 expr: '(' expr ')' .
 
     $default  reduce using rule 154 (expr)
 
 
-state 279
+State 279
 
   155 expr: '|' expr '|' .
 
     $default  reduce using rule 155 (expr)
 
 
-state 280
+State 280
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4517,7 +4517,7 @@ state 280
     $default  reduce using rule 174 (expr)
 
 
-state 281
+State 281
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4551,7 +4551,7 @@ state 281
     $default  reduce using rule 175 (expr)
 
 
-state 282
+State 282
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4582,7 +4582,7 @@ state 282
     $default  reduce using rule 172 (expr)
 
 
-state 283
+State 283
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4613,7 +4613,7 @@ state 283
     $default  reduce using rule 173 (expr)
 
 
-state 284
+State 284
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4640,7 +4640,7 @@ state 284
     $default  reduce using rule 168 (expr)
 
 
-state 285
+State 285
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4667,7 +4667,7 @@ state 285
     $default  reduce using rule 169 (expr)
 
 
-state 286
+State 286
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4702,7 +4702,7 @@ state 286
     '%'    shift, and go to state 220
 
 
-state 287
+State 287
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4729,7 +4729,7 @@ state 287
     $default  reduce using rule 170 (expr)
 
 
-state 288
+State 288
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4756,7 +4756,7 @@ state 288
     $default  reduce using rule 171 (expr)
 
 
-state 289
+State 289
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4781,7 +4781,7 @@ state 289
     $default  reduce using rule 166 (expr)
 
 
-state 290
+State 290
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4806,7 +4806,7 @@ state 290
     $default  reduce using rule 167 (expr)
 
 
-state 291
+State 291
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4827,7 +4827,7 @@ state 291
     $default  reduce using rule 164 (expr)
 
 
-state 292
+State 292
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -4848,7 +4848,7 @@ state 292
     $default  reduce using rule 165 (expr)
 
 
-state 293
+State 293
 
   163 expr: expr . '%' expr
   163     | expr '%' expr .
@@ -4869,7 +4869,7 @@ state 293
     $default  reduce using rule 163 (expr)
 
 
-state 294
+State 294
 
   159 expr: reduce_op foreach_header '(' . expr ')' '{' expr '}'
 
@@ -4907,7 +4907,7 @@ state 294
     id          go to state 83
 
 
-state 295
+State 295
 
   160 expr: reduce_op foreach_header '{' . expr '}'
 
@@ -4945,7 +4945,7 @@ state 295
     id          go to state 83
 
 
-state 296
+State 296
 
   161 expr: reduce_op2 foreach_header '(' . expr ')'
 
@@ -4983,7 +4983,7 @@ state 296
     id          go to state 83
 
 
-state 297
+State 297
 
   109 sent_bfs: T_BFS bfs_header_format bfs_filters sent_block . bfs_reverse
 
@@ -4994,7 +4994,7 @@ state 297
     bfs_reverse  go to state 347
 
 
-state 298
+State 298
 
    92 foreach_header: '(' id ':' . foreach_src '.' iterator1 ')'
 
@@ -5006,28 +5006,28 @@ state 298
     id           go to state 350
 
 
-state 299
+State 299
 
    99 foreach_filter: '(' bool_expr . ')'
 
     ')'  shift, and go to state 351
 
 
-state 300
+State 300
 
    90 sent_foreach: T_FOREACH foreach_header foreach_filter sent .
 
     $default  reduce using rule 90 (sent_foreach)
 
 
-state 301
+State 301
 
    91 sent_foreach: T_FOR foreach_header foreach_filter sent .
 
     $default  reduce using rule 91 (sent_foreach)
 
 
-state 302
+State 302
 
   150 sent_if: T_IF '(' bool_expr ')' . sent
   151        | T_IF '(' bool_expr ')' . sent T_ELSE sent
@@ -5097,7 +5097,7 @@ state 302
     id                         go to state 83
 
 
-state 303
+State 303
 
    89 sent_do_while: T_DO sent_block T_WHILE '(' . bool_expr ')'
 
@@ -5136,7 +5136,7 @@ state 303
     id          go to state 83
 
 
-state 304
+State 304
 
    88 sent_while: T_WHILE '(' bool_expr ')' . sent_block
 
@@ -5146,7 +5146,7 @@ state 304
     sb_begin    go to state 14
 
 
-state 305
+State 305
 
   201 lhs_list: lhs .
   202         | lhs . ',' lhs_list
@@ -5156,63 +5156,63 @@ state 305
     $default  reduce using rule 201 (lhs_list)
 
 
-state 306
+State 306
 
   214 lhs_list2: '<' lhs ';' lhs_list . '>'
 
     '>'  shift, and go to state 356
 
 
-state 307
+State 307
 
   204 field: id '.' id .
 
     $default  reduce using rule 204 (field)
 
 
-state 308
+State 308
 
   217 expr_user: '[' $@1 USER_TEXT ']' .
 
     $default  reduce using rule 217 (expr_user)
 
 
-state 309
+State 309
 
   129 sent_variable_decl: typedecl id '=' rhs .
 
     $default  reduce using rule 129 (sent_variable_decl)
 
 
-state 310
+State 310
 
   135 sent_defer_assignment: lhs T_LE rhs optional_bind .
 
     $default  reduce using rule 135 (sent_defer_assignment)
 
 
-state 311
+State 311
 
   138 optional_bind: '@' id .
 
     $default  reduce using rule 138 (optional_bind)
 
 
-state 312
+State 312
 
   132 sent_reduce_assignment: lhs reduce_eq rhs optional_bind .
 
     $default  reduce using rule 132 (sent_reduce_assignment)
 
 
-state 313
+State 313
 
   209 built_in: field '.' id arg_list .
 
     $default  reduce using rule 209 (built_in)
 
 
-state 314
+State 314
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -5247,21 +5247,21 @@ state 314
     ';'    shift, and go to state 357
 
 
-state 315
+State 315
 
   136 sent_argminmax_assignment: lhs_list2 minmax_eq rhs_list2 optional_bind .
 
     $default  reduce using rule 136 (sent_argminmax_assignment)
 
 
-state 316
+State 316
 
   153 sent_user: expr_user T_DOUBLE_COLON '[' lhs_list . ']'
 
     ']'  shift, and go to state 358
 
 
-state 317
+State 317
 
   213 expr_list: expr ',' . expr_list
 
@@ -5300,49 +5300,49 @@ state 317
     id          go to state 83
 
 
-state 318
+State 318
 
   210 arg_list: '(' expr_list ')' .
 
     $default  reduce using rule 210 (arg_list)
 
 
-state 319
+State 319
 
   207 built_in: id '.' id arg_list .
 
     $default  reduce using rule 207 (built_in)
 
 
-state 320
+State 320
 
   206 map_access: id '[' expr ']' .
 
     $default  reduce using rule 206 (map_access)
 
 
-state 321
+State 321
 
     5 proc_head: proc_name '(' arg_declist1 ';' arg_declist2 ')' proc_return_opt .
 
     $default  reduce using rule 5 (proc_head)
 
 
-state 322
+State 322
 
    13 arg_declist2: arg_declist2 ',' arg_decl .
 
     $default  reduce using rule 13 (arg_declist2)
 
 
-state 323
+State 323
 
    36 edge_type: T_EDGE '(' id . ')'
 
     ')'  shift, and go to state 360
 
 
-state 324
+State 324
 
    51 property: T_NODEPROP '<' prim_type '>' '(' . id ')'
 
@@ -5351,7 +5351,7 @@ state 324
     id  go to state 361
 
 
-state 325
+State 325
 
    52 property: T_NODEPROP '<' nodeedge_type '>' '(' . id ')'
 
@@ -5360,7 +5360,7 @@ state 325
     id  go to state 362
 
 
-state 326
+State 326
 
    53 property: T_NODEPROP '<' set_type '>' '(' . id ')'
 
@@ -5369,7 +5369,7 @@ state 326
     id  go to state 363
 
 
-state 327
+State 327
 
   205 field: T_EDGE '(' id ')' '.' . id
 
@@ -5378,7 +5378,7 @@ state 327
     id  go to state 364
 
 
-state 328
+State 328
 
    57 property: T_EDGEPROP '<' prim_type '>' '(' . id ')'
 
@@ -5387,7 +5387,7 @@ state 328
     id  go to state 365
 
 
-state 329
+State 329
 
    58 property: T_EDGEPROP '<' nodeedge_type '>' '(' . id ')'
 
@@ -5396,7 +5396,7 @@ state 329
     id  go to state 366
 
 
-state 330
+State 330
 
    59 property: T_EDGEPROP '<' set_type '>' '(' . id ')'
 
@@ -5405,7 +5405,7 @@ state 330
     id  go to state 367
 
 
-state 331
+State 331
 
    44 set_type: T_COLLECTION '<' set_type '>' '(' . id ')'
 
@@ -5414,28 +5414,28 @@ state 331
     id  go to state 368
 
 
-state 332
+State 332
 
    49 value_type: prim_type .
 
     $default  reduce using rule 49 (value_type)
 
 
-state 333
+State 333
 
    48 value_type: nodeedge_type .
 
     $default  reduce using rule 48 (value_type)
 
 
-state 334
+State 334
 
    50 map_type: T_MAP '<' key_type ',' value_type . '>'
 
     '>'  shift, and go to state 369
 
 
-state 335
+State 335
 
   116 bfs_header_format: '(' id ':' id . opt_tp '.' T_NODES from_or_semi id ')'
 
@@ -5446,21 +5446,21 @@ state 335
     opt_tp  go to state 371
 
 
-state 336
+State 336
 
   127 bfs_filter: '(' expr ')' .
 
     $default  reduce using rule 127 (bfs_filter)
 
 
-state 337
+State 337
 
   126 bfs_navigator: '[' expr ']' .
 
     $default  reduce using rule 126 (bfs_navigator)
 
 
-state 338
+State 338
 
   111 dfs_post: T_POST . bfs_filter sent_block
   112         | T_POST . sent_block
@@ -5473,21 +5473,21 @@ state 338
     bfs_filter  go to state 373
 
 
-state 339
+State 339
 
   108 sent_dfs: T_DFS bfs_header_format bfs_filters sent_block dfs_post .
 
     $default  reduce using rule 108 (sent_dfs)
 
 
-state 340
+State 340
 
   205 field: T_EDGE '(' id ')' . '.' id
 
     '.'  shift, and go to state 327
 
 
-state 341
+State 341
 
   158 expr: '(' prim_type ')' expr .
   163     | expr . '%' expr
@@ -5508,7 +5508,7 @@ state 341
     $default  reduce using rule 158 (expr)
 
 
-state 342
+State 342
 
   176 expr: expr '?' expr ':' . expr
 
@@ -5546,7 +5546,7 @@ state 342
     id          go to state 83
 
 
-state 343
+State 343
 
   159 expr: reduce_op foreach_header '(' expr . ')' '{' expr '}'
   163     | expr . '%' expr
@@ -5581,7 +5581,7 @@ state 343
     ')'    shift, and go to state 375
 
 
-state 344
+State 344
 
   160 expr: reduce_op foreach_header '{' expr . '}'
   163     | expr . '%' expr
@@ -5616,7 +5616,7 @@ state 344
     '}'    shift, and go to state 376
 
 
-state 345
+State 345
 
   161 expr: reduce_op2 foreach_header '(' expr . ')'
   163     | expr . '%' expr
@@ -5651,7 +5651,7 @@ state 345
     ')'    shift, and go to state 377
 
 
-state 346
+State 346
 
   114 bfs_reverse: T_BACK . bfs_filter sent_block
   115            | T_BACK . sent_block
@@ -5664,21 +5664,21 @@ state 346
     bfs_filter  go to state 379
 
 
-state 347
+State 347
 
   109 sent_bfs: T_BFS bfs_header_format bfs_filters sent_block bfs_reverse .
 
     $default  reduce using rule 109 (sent_bfs)
 
 
-state 348
+State 348
 
    92 foreach_header: '(' id ':' foreach_src . '.' iterator1 ')'
 
     '.'  shift, and go to state 380
 
 
-state 349
+State 349
 
    94 foreach_src: field . foreach_dir
 
@@ -5690,7 +5690,7 @@ state 349
     foreach_dir  go to state 383
 
 
-state 350
+State 350
 
    93 foreach_src: id . foreach_dir
   204 field: id . '.' id
@@ -5704,14 +5704,14 @@ state 350
     foreach_dir  go to state 384
 
 
-state 351
+State 351
 
    99 foreach_filter: '(' bool_expr ')' .
 
     $default  reduce using rule 99 (foreach_filter)
 
 
-state 352
+State 352
 
   150 sent_if: T_IF '(' bool_expr ')' sent .
   151        | T_IF '(' bool_expr ')' sent . T_ELSE sent
@@ -5722,21 +5722,21 @@ state 352
     $default  reduce using rule 150 (sent_if)
 
 
-state 353
+State 353
 
    89 sent_do_while: T_DO sent_block T_WHILE '(' bool_expr . ')'
 
     ')'  shift, and go to state 386
 
 
-state 354
+State 354
 
    88 sent_while: T_WHILE '(' bool_expr ')' sent_block .
 
     $default  reduce using rule 88 (sent_while)
 
 
-state 355
+State 355
 
   202 lhs_list: lhs ',' . lhs_list
 
@@ -5751,14 +5751,14 @@ state 355
     id          go to state 137
 
 
-state 356
+State 356
 
   214 lhs_list2: '<' lhs ';' lhs_list '>' .
 
     $default  reduce using rule 214 (lhs_list2)
 
 
-state 357
+State 357
 
   215 rhs_list2: '<' expr ';' . expr_list '>'
 
@@ -5797,112 +5797,112 @@ state 357
     id          go to state 83
 
 
-state 358
+State 358
 
   153 sent_user: expr_user T_DOUBLE_COLON '[' lhs_list ']' .
 
     $default  reduce using rule 153 (sent_user)
 
 
-state 359
+State 359
 
   213 expr_list: expr ',' expr_list .
 
     $default  reduce using rule 213 (expr_list)
 
 
-state 360
+State 360
 
    36 edge_type: T_EDGE '(' id ')' .
 
     $default  reduce using rule 36 (edge_type)
 
 
-state 361
+State 361
 
    51 property: T_NODEPROP '<' prim_type '>' '(' id . ')'
 
     ')'  shift, and go to state 389
 
 
-state 362
+State 362
 
    52 property: T_NODEPROP '<' nodeedge_type '>' '(' id . ')'
 
     ')'  shift, and go to state 390
 
 
-state 363
+State 363
 
    53 property: T_NODEPROP '<' set_type '>' '(' id . ')'
 
     ')'  shift, and go to state 391
 
 
-state 364
+State 364
 
   205 field: T_EDGE '(' id ')' '.' id .
 
     $default  reduce using rule 205 (field)
 
 
-state 365
+State 365
 
    57 property: T_EDGEPROP '<' prim_type '>' '(' id . ')'
 
     ')'  shift, and go to state 392
 
 
-state 366
+State 366
 
    58 property: T_EDGEPROP '<' nodeedge_type '>' '(' id . ')'
 
     ')'  shift, and go to state 393
 
 
-state 367
+State 367
 
    59 property: T_EDGEPROP '<' set_type '>' '(' id . ')'
 
     ')'  shift, and go to state 394
 
 
-state 368
+State 368
 
    44 set_type: T_COLLECTION '<' set_type '>' '(' id . ')'
 
     ')'  shift, and go to state 395
 
 
-state 369
+State 369
 
    50 map_type: T_MAP '<' key_type ',' value_type '>' .
 
     $default  reduce using rule 50 (map_type)
 
 
-state 370
+State 370
 
   118 opt_tp: '^' .
 
     $default  reduce using rule 118 (opt_tp)
 
 
-state 371
+State 371
 
   116 bfs_header_format: '(' id ':' id opt_tp . '.' T_NODES from_or_semi id ')'
 
     '.'  shift, and go to state 396
 
 
-state 372
+State 372
 
   112 dfs_post: T_POST sent_block .
 
     $default  reduce using rule 112 (dfs_post)
 
 
-state 373
+State 373
 
   111 dfs_post: T_POST bfs_filter . sent_block
 
@@ -5912,7 +5912,7 @@ state 373
     sb_begin    go to state 14
 
 
-state 374
+State 374
 
   163 expr: expr . '%' expr
   164     | expr . '*' expr
@@ -5947,35 +5947,35 @@ state 374
     $default  reduce using rule 176 (expr)
 
 
-state 375
+State 375
 
   159 expr: reduce_op foreach_header '(' expr ')' . '{' expr '}'
 
     '{'  shift, and go to state 398
 
 
-state 376
+State 376
 
   160 expr: reduce_op foreach_header '{' expr '}' .
 
     $default  reduce using rule 160 (expr)
 
 
-state 377
+State 377
 
   161 expr: reduce_op2 foreach_header '(' expr ')' .
 
     $default  reduce using rule 161 (expr)
 
 
-state 378
+State 378
 
   115 bfs_reverse: T_BACK sent_block .
 
     $default  reduce using rule 115 (bfs_reverse)
 
 
-state 379
+State 379
 
   114 bfs_reverse: T_BACK bfs_filter . sent_block
 
@@ -5985,7 +5985,7 @@ state 379
     sb_begin    go to state 14
 
 
-state 380
+State 380
 
    92 foreach_header: '(' id ':' foreach_src '.' . iterator1 ')'
 
@@ -6001,35 +6001,35 @@ state 380
     iterator1  go to state 408
 
 
-state 381
+State 381
 
    97 foreach_dir: '+' .
 
     $default  reduce using rule 97 (foreach_dir)
 
 
-state 382
+State 382
 
    96 foreach_dir: '-' .
 
     $default  reduce using rule 96 (foreach_dir)
 
 
-state 383
+State 383
 
    94 foreach_src: field foreach_dir .
 
     $default  reduce using rule 94 (foreach_src)
 
 
-state 384
+State 384
 
    93 foreach_src: id foreach_dir .
 
     $default  reduce using rule 93 (foreach_src)
 
 
-state 385
+State 385
 
   151 sent_if: T_IF '(' bool_expr ')' sent T_ELSE . sent
 
@@ -6098,91 +6098,91 @@ state 385
     id                         go to state 83
 
 
-state 386
+State 386
 
    89 sent_do_while: T_DO sent_block T_WHILE '(' bool_expr ')' .
 
     $default  reduce using rule 89 (sent_do_while)
 
 
-state 387
+State 387
 
   202 lhs_list: lhs ',' lhs_list .
 
     $default  reduce using rule 202 (lhs_list)
 
 
-state 388
+State 388
 
   215 rhs_list2: '<' expr ';' expr_list . '>'
 
     '>'  shift, and go to state 410
 
 
-state 389
+State 389
 
    51 property: T_NODEPROP '<' prim_type '>' '(' id ')' .
 
     $default  reduce using rule 51 (property)
 
 
-state 390
+State 390
 
    52 property: T_NODEPROP '<' nodeedge_type '>' '(' id ')' .
 
     $default  reduce using rule 52 (property)
 
 
-state 391
+State 391
 
    53 property: T_NODEPROP '<' set_type '>' '(' id ')' .
 
     $default  reduce using rule 53 (property)
 
 
-state 392
+State 392
 
    57 property: T_EDGEPROP '<' prim_type '>' '(' id ')' .
 
     $default  reduce using rule 57 (property)
 
 
-state 393
+State 393
 
    58 property: T_EDGEPROP '<' nodeedge_type '>' '(' id ')' .
 
     $default  reduce using rule 58 (property)
 
 
-state 394
+State 394
 
    59 property: T_EDGEPROP '<' set_type '>' '(' id ')' .
 
     $default  reduce using rule 59 (property)
 
 
-state 395
+State 395
 
    44 set_type: T_COLLECTION '<' set_type '>' '(' id ')' .
 
     $default  reduce using rule 44 (set_type)
 
 
-state 396
+State 396
 
   116 bfs_header_format: '(' id ':' id opt_tp '.' . T_NODES from_or_semi id ')'
 
     T_NODES  shift, and go to state 411
 
 
-state 397
+State 397
 
   111 dfs_post: T_POST bfs_filter sent_block .
 
     $default  reduce using rule 111 (dfs_post)
 
 
-state 398
+State 398
 
   159 expr: reduce_op foreach_header '(' expr ')' '{' . expr '}'
 
@@ -6220,91 +6220,91 @@ state 398
     id          go to state 83
 
 
-state 399
+State 399
 
   114 bfs_reverse: T_BACK bfs_filter sent_block .
 
     $default  reduce using rule 114 (bfs_reverse)
 
 
-state 400
+State 400
 
   106 iterator1: T_ITEMS .
 
     $default  reduce using rule 106 (iterator1)
 
 
-state 401
+State 401
 
   100 iterator1: T_NODES .
 
     $default  reduce using rule 100 (iterator1)
 
 
-state 402
+State 402
 
   101 iterator1: T_EDGES .
 
     $default  reduce using rule 101 (iterator1)
 
 
-state 403
+State 403
 
   102 iterator1: T_NBRS .
 
     $default  reduce using rule 102 (iterator1)
 
 
-state 404
+State 404
 
   103 iterator1: T_IN_NBRS .
 
     $default  reduce using rule 103 (iterator1)
 
 
-state 405
+State 405
 
   104 iterator1: T_UP_NBRS .
 
     $default  reduce using rule 104 (iterator1)
 
 
-state 406
+State 406
 
   105 iterator1: T_DOWN_NBRS .
 
     $default  reduce using rule 105 (iterator1)
 
 
-state 407
+State 407
 
   107 iterator1: T_COMMON_NBRS . '(' id ')'
 
     '('  shift, and go to state 413
 
 
-state 408
+State 408
 
    92 foreach_header: '(' id ':' foreach_src '.' iterator1 . ')'
 
     ')'  shift, and go to state 414
 
 
-state 409
+State 409
 
   151 sent_if: T_IF '(' bool_expr ')' sent T_ELSE sent .
 
     $default  reduce using rule 151 (sent_if)
 
 
-state 410
+State 410
 
   215 rhs_list2: '<' expr ';' expr_list '>' .
 
     $default  reduce using rule 215 (rhs_list2)
 
 
-state 411
+State 411
 
   116 bfs_header_format: '(' id ':' id opt_tp '.' T_NODES . from_or_semi id ')'
 
@@ -6314,7 +6314,7 @@ state 411
     from_or_semi  go to state 417
 
 
-state 412
+State 412
 
   159 expr: reduce_op foreach_header '(' expr ')' '{' expr . '}'
   163     | expr . '%' expr
@@ -6349,7 +6349,7 @@ state 412
     '}'    shift, and go to state 418
 
 
-state 413
+State 413
 
   107 iterator1: T_COMMON_NBRS '(' . id ')'
 
@@ -6358,28 +6358,28 @@ state 413
     id  go to state 419
 
 
-state 414
+State 414
 
    92 foreach_header: '(' id ':' foreach_src '.' iterator1 ')' .
 
     $default  reduce using rule 92 (foreach_header)
 
 
-state 415
+State 415
 
   119 from_or_semi: T_FROM .
 
     $default  reduce using rule 119 (from_or_semi)
 
 
-state 416
+State 416
 
   120 from_or_semi: ';' .
 
     $default  reduce using rule 120 (from_or_semi)
 
 
-state 417
+State 417
 
   116 bfs_header_format: '(' id ':' id opt_tp '.' T_NODES from_or_semi . id ')'
 
@@ -6388,35 +6388,35 @@ state 417
     id  go to state 420
 
 
-state 418
+State 418
 
   159 expr: reduce_op foreach_header '(' expr ')' '{' expr '}' .
 
     $default  reduce using rule 159 (expr)
 
 
-state 419
+State 419
 
   107 iterator1: T_COMMON_NBRS '(' id . ')'
 
     ')'  shift, and go to state 421
 
 
-state 420
+State 420
 
   116 bfs_header_format: '(' id ':' id opt_tp '.' T_NODES from_or_semi id . ')'
 
     ')'  shift, and go to state 422
 
 
-state 421
+State 421
 
   107 iterator1: T_COMMON_NBRS '(' id ')' .
 
     $default  reduce using rule 107 (iterator1)
 
 
-state 422
+State 422
 
   116 bfs_header_format: '(' id ':' id opt_tp '.' T_NODES from_or_semi id ')' .
 

--- a/src/parse/gm_grammer.tab.c
+++ b/src/parse/gm_grammer.tab.c
@@ -1,20 +1,19 @@
-
-/* A Bison parser, made by GNU Bison 2.4.1.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Skeleton implementation for Bison GLR parsers in C
-   
-      Copyright (C) 2002, 2003, 2004, 2005, 2006 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 2002-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -27,7 +26,7 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
@@ -37,7 +36,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "2.4.1"
+#define YYBISON_VERSION "3.0.4"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "glr.c"
@@ -45,16 +44,13 @@
 /* Pure parsers.  */
 #define YYPURE 0
 
-/* Using locations.  */
-#define YYLSP_NEEDED 1
 
 
 
 
-/* Copy the first part of user declarations.  */
 
-/* Line 172 of glr.c  */
-#line 6 "parse/gm_grammer.y"
+/* First part of user declarations.  */
+#line 6 "parse/gm_grammer.y" /* glr.c:240  */
 
     #include <stdio.h>
     #include <string.h>
@@ -66,18 +62,17 @@
     extern void yyerror(const char* str);
     extern int yylex();
 
+#line 66 "./parse/gm_grammer.tab.c" /* glr.c:240  */
 
-/* Line 172 of glr.c  */
-#line 72 "./parse/gm_grammer.tab.c"
-
-
+# ifndef YY_NULLPTR
+#  if defined __cplusplus && 201103L <= __cplusplus
+#   define YY_NULLPTR nullptr
+#  else
+#   define YY_NULLPTR 0
+#  endif
+# endif
 
 #include "gm_grammer.tab.h"
-
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
 
 /* Enabling verbose error messages.  */
 #ifdef YYERROR_VERBOSE
@@ -87,63 +82,35 @@
 # define YYERROR_VERBOSE 0
 #endif
 
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
-#endif
-
 /* Default (constant) value used for initialization for null
-   right-hand sides.  Unlike the standard yacc.c template,
-   here we set the default value of $$ to a zeroed-out value.
-   Since the default value is undefined, this behavior is
-   technically correct.  */
+   right-hand sides.  Unlike the standard yacc.c template, here we set
+   the default value of $$ to a zeroed-out value.  Since the default
+   value is undefined, this behavior is technically correct.  */
 static YYSTYPE yyval_default;
+static YYLTYPE yyloc_default
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+  = { 1, 1, 1, 1 }
+# endif
+;
 
 /* Copy the second part of user declarations.  */
 
-
-/* Line 243 of glr.c  */
-#line 107 "./parse/gm_grammer.tab.c"
+#line 99 "./parse/gm_grammer.tab.c" /* glr.c:263  */
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #ifndef YY_
-# if YYENABLE_NLS
+# if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#   define YY_(msgid) dgettext ("bison-runtime", msgid)
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(msgid) msgid
+#  define YY_(Msgid) Msgid
 # endif
-#endif
-
-/* Suppress unused-variable warnings by "using" E.  */
-#if ! defined lint || defined __GNUC__
-# define YYUSE(e) ((void) (e))
-#else
-# define YYUSE(e) /* empty */
-#endif
-
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(n) (n)
-#else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int i)
-#else
-static int
-YYID (i)
-    int i;
-#endif
-{
-  return i;
-}
 #endif
 
 #ifndef YYFREE
@@ -169,26 +136,67 @@ YYID (i)
 #ifndef YYSETJMP
 # include <setjmp.h>
 # define YYJMP_BUF jmp_buf
-# define YYSETJMP(env) setjmp (env)
-# define YYLONGJMP(env, val) longjmp (env, val)
+# define YYSETJMP(Env) setjmp (Env)
+/* Pacify clang.  */
+# define YYLONGJMP(Env, Val) (longjmp (Env, Val), YYASSERT (0))
 #endif
 
-/*-----------------.
-| GCC extensions.  |
-`-----------------*/
-
-#ifndef __attribute__
-/* This feature is available in gcc versions 2.5 and later.  */
-# if (! defined __GNUC__ || __GNUC__ < 2 \
-      || (__GNUC__ == 2 && __GNUC_MINOR__ < 5) || __STRICT_ANSI__)
-#  define __attribute__(Spec) /* empty */
+#ifndef YY_ATTRIBUTE
+# if (defined __GNUC__                                               \
+      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
+     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
+#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+# else
+#  define YY_ATTRIBUTE(Spec) /* empty */
 # endif
 #endif
 
-#define YYOPTIONAL_LOC(Name) Name
+#ifndef YY_ATTRIBUTE_PURE
+# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
+#endif
+
+#if !defined _Noreturn \
+     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
+# if defined _MSC_VER && 1200 <= _MSC_VER
+#  define _Noreturn __declspec (noreturn)
+# else
+#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+# endif
+#endif
+
+/* Suppress unused-variable warnings by "using" E.  */
+#if ! defined lint || defined __GNUC__
+# define YYUSE(E) ((void) (E))
+#else
+# define YYUSE(E) /* empty */
+#endif
+
+#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
+    _Pragma ("GCC diagnostic push") \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+    _Pragma ("GCC diagnostic pop")
+#else
+# define YY_INITIAL_VALUE(Value) Value
+#endif
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
+#endif
+
 
 #ifndef YYASSERT
-# define YYASSERT(condition) ((void) ((condition) || (abort (), 0)))
+# define YYASSERT(Condition) ((void) ((Condition) || (abort (), 0)))
 #endif
 
 /* YYFINAL -- State number of the termination state.  */
@@ -214,7 +222,7 @@ YYID (i)
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   330
 
-#define YYTRANSLATE(YYX)						\
+#define YYTRANSLATE(YYX)                                                \
   ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
@@ -257,112 +265,6 @@ static const unsigned char yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const unsigned short int yyprhs[] =
-{
-       0,     0,     3,     4,     7,    10,    16,    24,    27,    30,
-      31,    33,    35,    39,    41,    45,    46,    48,    51,    54,
-      58,    60,    62,    64,    66,    68,    70,    72,    74,    76,
-      78,    80,    82,    84,    86,    88,    93,    95,   100,   102,
-     107,   109,   114,   116,   121,   123,   131,   136,   138,   140,
-     142,   144,   151,   159,   167,   175,   180,   185,   190,   198,
-     206,   214,   219,   224,   229,   231,   235,   237,   241,   243,
-     245,   246,   249,   252,   255,   257,   259,   261,   264,   267,
-     270,   272,   275,   277,   279,   282,   285,   288,   290,   292,
-     298,   305,   310,   315,   323,   326,   329,   330,   332,   334,
-     335,   339,   341,   343,   345,   347,   349,   351,   353,   358,
-     364,   370,   371,   375,   378,   379,   383,   386,   397,   398,
-     400,   402,   404,   405,   407,   409,   412,   415,   419,   423,
-     426,   431,   433,   437,   442,   446,   450,   455,   460,   461,
-     464,   466,   468,   470,   472,   474,   476,   478,   480,   482,
-     485,   487,   493,   501,   503,   509,   513,   517,   520,   523,
-     528,   537,   543,   549,   552,   556,   560,   564,   568,   572,
-     576,   580,   584,   588,   592,   596,   600,   604,   610,   612,
-     614,   616,   618,   620,   622,   624,   626,   628,   630,   632,
-     634,   636,   638,   640,   642,   644,   646,   648,   650,   652,
-     654,   656,   658,   660,   664,   666,   670,   677,   682,   687,
-     690,   695,   699,   702,   704,   708,   714,   720,   721,   726
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const short int yyrhs[] =
-{
-     100,     0,    -1,    -1,   100,   101,    -1,   102,   123,    -1,
-     103,    85,   104,    86,   107,    -1,   103,    85,   104,    87,
-     106,    86,   107,    -1,     3,   178,    -1,     9,   178,    -1,
-      -1,   105,    -1,   109,    -1,   105,    88,   109,    -1,   109,
-      -1,   106,    88,   109,    -1,    -1,   108,    -1,    76,   113,
-      -1,    76,   115,    -1,   110,    76,   111,    -1,   122,    -1,
-     113,    -1,   112,    -1,   121,    -1,   114,    -1,   117,    -1,
-     120,    -1,     4,    -1,    18,    -1,    22,    -1,    19,    -1,
-      21,    -1,    20,    -1,   115,    -1,   116,    -1,     5,    85,
-     178,    86,    -1,     5,    -1,     7,    85,   178,    86,    -1,
-       7,    -1,    10,    85,   178,    86,    -1,    10,    -1,    12,
-      85,   178,    86,    -1,    12,    -1,    11,    85,   178,    86,
-      -1,    11,    -1,    14,    77,   117,    78,    85,   178,    86,
-      -1,    14,    77,   117,    78,    -1,   114,    -1,   113,    -1,
-     114,    -1,   113,    -1,    15,    77,   118,    88,   119,    78,
-      -1,     6,    77,   113,    78,    85,   178,    86,    -1,     6,
-      77,   114,    78,    85,   178,    86,    -1,     6,    77,   117,
-      78,    85,   178,    86,    -1,     6,    77,   113,    78,    -1,
-       6,    77,   114,    78,    -1,     6,    77,   117,    78,    -1,
-       8,    77,   113,    78,    85,   178,    86,    -1,     8,    77,
-     114,    78,    85,   178,    86,    -1,     8,    77,   117,    78,
-      85,   178,    86,    -1,     8,    77,   113,    78,    -1,     8,
-      77,   114,    78,    -1,     8,    77,   117,    78,    -1,   178,
-      -1,   122,    88,   178,    -1,   124,    -1,   125,   127,   126,
-      -1,    89,    -1,    90,    -1,    -1,   127,   128,    -1,   150,
-      87,    -1,   148,    87,    -1,   124,    -1,   132,    -1,   159,
-      -1,   151,    87,    -1,   152,    87,    -1,   131,    87,    -1,
-     130,    -1,   158,    87,    -1,   139,    -1,   138,    -1,   129,
-      87,    -1,   160,    87,    -1,   153,    87,    -1,    87,    -1,
-     171,    -1,    56,    85,   162,    86,   124,    -1,    55,   124,
-      56,    85,   162,    86,    -1,    29,   133,   136,   128,    -1,
-      30,   133,   136,   128,    -1,    85,   178,    76,   134,    91,
-     137,    86,    -1,   178,   135,    -1,   169,   135,    -1,    -1,
-      80,    -1,    79,    -1,    -1,    85,   162,    86,    -1,    31,
-      -1,    32,    -1,    33,    -1,    34,    -1,    35,    -1,    36,
-      -1,    13,    -1,    37,    85,   178,    86,    -1,    16,   142,
-     145,   124,   140,    -1,    24,   142,   145,   124,   141,    -1,
-      -1,    17,   147,   124,    -1,    17,   124,    -1,    -1,    28,
-     147,   124,    -1,    28,   124,    -1,    85,   178,    76,   178,
-     143,    91,    31,   144,   178,    86,    -1,    -1,    92,    -1,
-      26,    -1,    87,    -1,    -1,   146,    -1,   147,    -1,   146,
-     147,    -1,   147,   146,    -1,    93,   161,    94,    -1,    85,
-     161,    86,    -1,   111,   149,    -1,   111,   178,    95,   157,
-      -1,   122,    -1,   166,    95,   157,    -1,   166,   155,   157,
-     154,    -1,   166,    61,   154,    -1,   166,    62,   154,    -1,
-     166,    51,   157,   154,    -1,   174,   156,   175,   154,    -1,
-      -1,    96,   178,    -1,    57,    -1,    58,    -1,    59,    -1,
-      60,    -1,    63,    -1,    64,    -1,    59,    -1,    60,    -1,
-     161,    -1,    23,   161,    -1,    23,    -1,    53,    85,   162,
-      86,   128,    -1,    53,    85,   162,    86,   128,    54,   128,
-      -1,   176,    -1,   176,    67,    93,   167,    94,    -1,    85,
-     161,    86,    -1,    97,   161,    97,    -1,    80,   161,    -1,
-      98,   161,    -1,    85,   113,    86,   161,    -1,   163,   133,
-      85,   161,    86,    89,   161,    90,    -1,   163,   133,    89,
-     161,    90,    -1,   164,   133,    85,   161,    86,    -1,   164,
-     133,    -1,   161,    83,   161,    -1,   161,    81,   161,    -1,
-     161,    82,   161,    -1,   161,    79,   161,    -1,   161,    80,
-     161,    -1,   161,    51,   161,    -1,   161,    52,   161,    -1,
-     161,    77,   161,    -1,   161,    78,   161,    -1,   161,    49,
-     161,    -1,   161,    50,   161,    -1,   161,    47,   161,    -1,
-     161,    48,   161,    -1,   161,    75,   161,    76,   161,    -1,
-      74,    -1,    72,    -1,    73,    -1,   165,    -1,    69,    -1,
-     168,    -1,   169,    -1,   171,    -1,   176,    -1,   170,    -1,
-     161,    -1,    38,    -1,    39,    -1,    40,    -1,    41,    -1,
-      44,    -1,    43,    -1,    45,    -1,    42,    -1,    66,    -1,
-      65,    -1,   168,    -1,   169,    -1,   170,    -1,   166,    -1,
-     166,    88,   167,    -1,   178,    -1,   178,    91,   178,    -1,
-       7,    85,   178,    86,    91,   178,    -1,   178,    93,   161,
-      94,    -1,   178,    91,   178,   172,    -1,   178,   172,    -1,
-     169,    91,   178,   172,    -1,    85,   173,    86,    -1,    85,
-      86,    -1,   161,    -1,   161,    88,   173,    -1,    77,   166,
-      87,   167,    78,    -1,    77,   161,    87,   173,    78,    -1,
-      -1,    93,   177,    71,    94,    -1,    70,    -1
-};
-
 /* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
 static const unsigned short int yyrline[] =
 {
@@ -391,7 +293,7 @@ static const unsigned short int yyrline[] =
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
+#if YYDEBUG || YYERROR_VERBOSE || 0
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
@@ -426,184 +328,15 @@ static const char *const yytname[] =
   "rhs", "sent_return", "sent_if", "sent_user", "expr", "bool_expr",
   "reduce_op", "reduce_op2", "inf", "lhs", "lhs_list", "scala", "field",
   "map_access", "built_in", "arg_list", "expr_list", "lhs_list2",
-  "rhs_list2", "expr_user", "$@1", "id", 0
+  "rhs_list2", "expr_user", "$@1", "id", YY_NULLPTR
 };
 #endif
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const unsigned char yyr1[] =
-{
-       0,    99,   100,   100,   101,   102,   102,   103,   103,   104,
-     104,   105,   105,   106,   106,   107,   107,   108,   108,   109,
-     110,   111,   111,   111,   111,   111,   111,   112,   113,   113,
-     113,   113,   113,   114,   114,   115,   115,   116,   116,   117,
-     117,   117,   117,   117,   117,   117,   117,   118,   118,   119,
-     119,   120,   121,   121,   121,   121,   121,   121,   121,   121,
-     121,   121,   121,   121,   122,   122,   123,   124,   125,   126,
-     127,   127,   128,   128,   128,   128,   128,   128,   128,   128,
-     128,   128,   128,   128,   128,   128,   128,   128,   129,   130,
-     131,   132,   132,   133,   134,   134,   135,   135,   135,   136,
-     136,   137,   137,   137,   137,   137,   137,   137,   137,   138,
-     139,   140,   140,   140,   141,   141,   141,   142,   143,   143,
-     144,   144,   145,   145,   145,   145,   145,   146,   147,   148,
-     148,   149,   150,   151,   151,   151,   152,   153,   154,   154,
-     155,   155,   155,   155,   155,   155,   156,   156,   157,   158,
-     158,   159,   159,   160,   160,   161,   161,   161,   161,   161,
-     161,   161,   161,   161,   161,   161,   161,   161,   161,   161,
-     161,   161,   161,   161,   161,   161,   161,   161,   161,   161,
-     161,   161,   161,   161,   161,   161,   161,   161,   162,   163,
-     163,   163,   163,   163,   163,   163,   164,   165,   165,   166,
-     166,   166,   167,   167,   168,   169,   169,   170,   171,   171,
-     171,   172,   172,   173,   173,   174,   175,   177,   176,   178
-};
-
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const unsigned char yyr2[] =
-{
-       0,     2,     0,     2,     2,     5,     7,     2,     2,     0,
-       1,     1,     3,     1,     3,     0,     1,     2,     2,     3,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     4,     1,     4,     1,     4,
-       1,     4,     1,     4,     1,     7,     4,     1,     1,     1,
-       1,     6,     7,     7,     7,     4,     4,     4,     7,     7,
-       7,     4,     4,     4,     1,     3,     1,     3,     1,     1,
-       0,     2,     2,     2,     1,     1,     1,     2,     2,     2,
-       1,     2,     1,     1,     2,     2,     2,     1,     1,     5,
-       6,     4,     4,     7,     2,     2,     0,     1,     1,     0,
-       3,     1,     1,     1,     1,     1,     1,     1,     4,     5,
-       5,     0,     3,     2,     0,     3,     2,    10,     0,     1,
-       1,     1,     0,     1,     1,     2,     2,     3,     3,     2,
-       4,     1,     3,     4,     3,     3,     4,     4,     0,     2,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     2,
-       1,     5,     7,     1,     5,     3,     3,     2,     2,     4,
-       8,     5,     5,     2,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     3,     5,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     3,     1,     3,     6,     4,     4,     2,
-       4,     3,     2,     1,     3,     5,     5,     0,     4,     1
-};
-
-/* YYDPREC[RULE-NUM] -- Dynamic precedence of rule #RULE-NUM (0 if none).  */
-static const unsigned char yydprec[] =
-{
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0
-};
-
-/* YYMERGER[RULE-NUM] -- Index of merging function for rule #RULE-NUM.  */
-static const unsigned char yymerger[] =
-{
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0
-};
-
-/* YYDEFACT[S] -- default rule to reduce with in state S when YYTABLE
-   doesn't specify something else to do.  Zero means the default is an
-   error.  */
-static const unsigned char yydefact[] =
-{
-       2,     0,     1,     0,     0,     3,     0,     0,   219,     7,
-       8,    68,     4,    66,    70,     9,     0,     0,    10,    11,
-       0,    20,    64,    27,    36,     0,    38,     0,    40,    44,
-      42,     0,     0,     0,    28,    30,    32,    31,    29,   150,
-       0,     0,     0,     0,     0,     0,     0,    87,    69,   217,
-       0,    22,    21,    24,    33,    34,    25,    26,    23,    74,
-      67,    71,     0,    80,     0,    75,    83,    82,     0,     0,
-       0,     0,     0,     0,    76,     0,     0,   199,   200,   201,
-      88,     0,   153,   204,    15,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   122,
-       0,   189,   190,   191,   192,   196,   194,   193,   195,   198,
-     197,   182,   179,   180,   178,     0,     0,     0,     0,   149,
-       0,     0,   181,   183,   184,   187,   185,   186,   122,     0,
-      99,    99,     0,     0,     0,     0,   200,   204,     0,   131,
-     129,    64,    84,    79,    73,    72,    77,    78,    86,    81,
-      85,     0,   140,   141,   142,   143,   138,   138,   144,   145,
-       0,     0,     0,   146,   147,     0,     0,     0,     0,     0,
-     209,     0,     5,    16,     0,    13,    12,    38,    19,    65,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    48,    47,     0,     0,     0,     0,     0,   123,
-     124,     0,   157,     0,     0,     0,   158,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   163,     0,     0,     0,     0,     0,   188,     0,
-       0,     0,     0,     0,     0,     0,   138,   148,     0,   134,
-     135,   132,   138,     0,     0,   138,     0,   212,   213,     0,
-     205,     0,    17,    18,    15,     0,     0,    35,    55,    56,
-      57,    37,    61,    62,    63,    39,    43,    41,    46,     0,
-       0,     0,     0,   111,   125,   126,     0,     0,   155,   156,
-     175,   176,   173,   174,   169,   170,     0,   171,   172,   167,
-     168,   165,   166,   164,     0,     0,     0,   114,     0,     0,
-      91,    92,     0,     0,     0,   202,     0,   205,   218,   130,
-     136,   139,   133,   210,     0,   137,     0,     0,   211,   208,
-     207,     6,    14,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,    50,    49,     0,   118,   128,   127,     0,   109,
-       0,   159,     0,     0,     0,     0,     0,   110,     0,    96,
-       0,   100,   151,     0,    89,     0,   215,     0,   154,   214,
-      37,     0,     0,     0,   206,     0,     0,     0,     0,    51,
-     119,     0,   113,     0,   177,     0,   161,   162,   116,     0,
-       0,    98,    97,    95,    94,     0,    90,   203,     0,    52,
-      53,    54,    58,    59,    60,    45,     0,   112,     0,   115,
-     107,   101,   102,   103,   104,   105,   106,     0,     0,   152,
-     216,     0,     0,     0,    93,   120,   121,     0,   160,     0,
-       0,   108,   117
-};
-
-/* YYPDEFGOTO[NTERM-NUM].  */
-static const short int yydefgoto[] =
-{
-      -1,     1,     5,     6,     7,    17,    18,   174,   172,   173,
-      19,    20,    50,    51,    52,    53,    54,    55,    56,   194,
-     334,    57,    58,    21,    12,    59,    14,    60,    16,    61,
-      62,    63,    64,    65,   130,   348,   383,   226,   408,    66,
-      67,   339,   347,    99,   371,   417,   198,   199,   200,    68,
-     140,    69,    70,    71,    72,   239,   161,   165,   236,    73,
-      74,    75,   228,   229,   120,   121,   122,    76,   306,   123,
-     124,   125,   126,   170,   249,    81,   245,   127,   138,    83
-};
-
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
 #define YYPACT_NINF -292
+#define YYTABLE_NINF -1
+
+  /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+     STATE-NUM.  */
 static const short int yypact[] =
 {
     -292,   154,  -292,   -48,   -48,  -292,   -61,   -52,  -292,  -292,
@@ -651,7 +384,57 @@ static const short int yypact[] =
      327,  -292,  -292
 };
 
-/* YYPGOTO[NTERM-NUM].  */
+  /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+     Performed when YYTABLE does not specify something else to do.  Zero
+     means the default is an error.  */
+static const unsigned char yydefact[] =
+{
+       2,     0,     1,     0,     0,     3,     0,     0,   219,     7,
+       8,    68,     4,    66,    70,     9,     0,     0,    10,    11,
+       0,    20,    64,    27,    36,     0,    38,     0,    40,    44,
+      42,     0,     0,     0,    28,    30,    32,    31,    29,   150,
+       0,     0,     0,     0,     0,     0,     0,    87,    69,   217,
+       0,    22,    21,    24,    33,    34,    25,    26,    23,    74,
+      67,    71,     0,    80,     0,    75,    83,    82,     0,     0,
+       0,     0,     0,     0,    76,     0,     0,   199,   200,   201,
+      88,     0,   153,   204,    15,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   122,
+       0,   189,   190,   191,   192,   196,   194,   193,   195,   198,
+     197,   182,   179,   180,   178,     0,     0,     0,     0,   149,
+       0,     0,   181,   183,   184,   187,   185,   186,   122,     0,
+      99,    99,     0,     0,     0,     0,   200,   204,     0,   131,
+     129,    64,    84,    79,    73,    72,    77,    78,    86,    81,
+      85,     0,   140,   141,   142,   143,   138,   138,   144,   145,
+       0,     0,     0,   146,   147,     0,     0,     0,     0,     0,
+     209,     0,     5,    16,     0,    13,    12,    38,    19,    65,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    48,    47,     0,     0,     0,     0,     0,   123,
+     124,     0,   157,     0,     0,     0,   158,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   163,     0,     0,     0,     0,     0,   188,     0,
+       0,     0,     0,     0,     0,     0,   138,   148,     0,   134,
+     135,   132,   138,     0,     0,   138,     0,   212,   213,     0,
+     205,     0,    17,    18,    15,     0,     0,    35,    55,    56,
+      57,    37,    61,    62,    63,    39,    43,    41,    46,     0,
+       0,     0,     0,   111,   125,   126,     0,     0,   155,   156,
+     175,   176,   173,   174,   169,   170,     0,   171,   172,   167,
+     168,   165,   166,   164,     0,     0,     0,   114,     0,     0,
+      91,    92,     0,     0,     0,   202,     0,   205,   218,   130,
+     136,   139,   133,   210,     0,   137,     0,     0,   211,   208,
+     207,     6,    14,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    50,    49,     0,   118,   128,   127,     0,   109,
+       0,   159,     0,     0,     0,     0,     0,   110,     0,    96,
+       0,   100,   151,     0,    89,     0,   215,     0,   154,   214,
+      37,     0,     0,     0,   206,     0,     0,     0,     0,    51,
+     119,     0,   113,     0,   177,     0,   161,   162,   116,     0,
+       0,    98,    97,    95,    94,     0,    90,   203,     0,    52,
+      53,    54,    58,    59,    60,    45,     0,   112,     0,   115,
+     107,   101,   102,   103,   104,   105,   106,     0,     0,   152,
+     216,     0,     0,     0,    93,   120,   121,     0,   160,     0,
+       0,   108,   117
+};
+
+  /* YYPGOTO[NTERM-NUM].  */
 static const short int yypgoto[] =
 {
     -292,  -292,  -292,  -292,  -292,  -292,  -292,  -292,   167,  -292,
@@ -664,11 +447,22 @@ static const short int yypgoto[] =
      -12,    -5,    -1,  -119,  -291,  -292,  -292,     5,  -292,    -3
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If zero, do what YYDEFACT says.
-   If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -1
+  /* YYDEFGOTO[NTERM-NUM].  */
+static const short int yydefgoto[] =
+{
+      -1,     1,     5,     6,     7,    17,    18,   174,   172,   173,
+      19,    20,    50,    51,    52,    53,    54,    55,    56,   194,
+     334,    57,    58,    21,    12,    59,    14,    60,    16,    61,
+      62,    63,    64,    65,   130,   348,   383,   226,   408,    66,
+      67,   339,   347,    99,   371,   417,   198,   199,   200,    68,
+     140,    69,    70,    71,    72,   239,   161,   165,   236,    73,
+      74,    75,   228,   229,   120,   121,   122,    76,   306,   123,
+     124,   125,   126,   170,   249,    81,   245,   127,   138,    83
+};
+
+  /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+     positive, shift that token.  If negative, reduce the rule whose
+     number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const unsigned short int yytable[] =
 {
        9,    10,    13,   135,    78,   231,   181,    77,   185,   175,
@@ -766,6 +560,291 @@ static const unsigned short int yytable[] =
      218,   219,   220,    23,    24,    25,   177,    27,     0,    28,
       29,    30,     0,    31,    32,     0,     0,    34,    35,    36,
       37,    38
+};
+
+static const short int yycheck[] =
+{
+       3,     4,     6,    46,    16,   134,    90,    16,    92,    85,
+      86,    16,    15,    97,   199,    16,    90,     7,    92,   246,
+      26,    16,    70,    97,   226,   227,   317,    85,    89,    42,
+     157,    89,   116,    85,    46,   160,   161,    46,    85,     7,
+      44,    46,    88,    46,    91,    76,    93,    50,    88,    51,
+      18,    19,    20,    21,    22,    57,    58,    59,    60,    61,
+      62,    63,    64,    90,    85,    92,   357,    85,    89,    96,
+      38,    39,    40,    41,    42,    43,    44,    45,    86,    87,
+      70,    87,    85,    86,    77,    88,    89,   171,    91,    85,
+      93,    94,    95,    95,    77,    98,   225,    65,    66,    85,
+     302,    69,    70,    85,    72,    73,    74,   120,   121,   236,
+     235,    93,    80,    85,    91,   242,    93,    85,   245,    51,
+      52,    79,    80,    85,   243,    93,   129,    77,   355,    97,
+      98,   250,    86,    91,    88,    77,    47,    48,    49,    50,
+      51,    52,    81,    82,    83,    77,    78,    79,    80,    81,
+      82,    83,    85,   338,     0,    59,    60,     3,    85,   162,
+      85,   346,    85,     9,    75,   168,    77,    78,    79,    80,
+      81,    82,    83,    87,   303,    87,    10,    11,    12,   255,
+      14,    79,    80,   385,    87,   269,    97,    39,    13,   232,
+      87,    87,    87,    87,   198,   269,    87,    87,   201,    91,
+      67,    76,    85,   246,    85,    56,    31,    32,    33,    34,
+      35,    36,    37,    87,   226,   227,    71,   226,   227,   223,
+     232,   226,   227,   232,    95,   226,   227,   232,    96,   232,
+     233,   226,   227,    77,   246,   238,    93,   246,    85,    78,
+      78,   246,     5,   246,    47,    48,    49,    50,    51,    52,
+      86,    78,   255,   256,    86,    18,    19,    20,    21,    22,
+      78,    78,    78,   115,   116,   117,   118,   270,     5,    78,
+       7,    86,    75,    86,    77,    78,    79,    80,    81,    82,
+      83,    18,    19,    20,    21,    22,   298,    86,    88,    76,
+     302,    94,    85,   302,    86,   298,    93,   302,    76,   151,
+     304,   302,    79,    80,    81,    82,    83,   302,   160,   161,
+      85,    85,   355,    86,    86,   167,    85,   169,    94,    86,
+      85,   324,   325,   326,   327,   328,   329,   330,   331,    85,
+      85,    91,    85,    85,   338,    85,    85,    17,    86,    28,
+      86,    88,   346,   355,   196,   197,   355,    78,    86,    94,
+     355,    78,   355,    92,    54,   207,   208,   209,   210,   211,
+     212,   213,   214,   215,   216,   217,   218,   219,   220,   373,
+      91,    86,     5,   385,     7,   379,   385,    10,    11,    12,
+     385,    14,    86,   235,   385,    18,    19,    20,    21,    22,
+     385,    86,   244,    86,    86,     7,    86,    91,    86,    86,
+      78,    31,    85,    89,    47,    48,    49,    50,    51,    52,
+     413,    86,    86,    86,   417,    47,    87,    49,    50,    51,
+      52,   254,    50,   131,   350,   277,    38,    39,    40,    41,
+      42,    43,    44,    45,    77,    78,    79,    80,    81,    82,
+      83,   171,   294,   295,   296,    77,    78,    79,    80,    81,
+      82,    83,    40,    65,    66,    -1,   128,    69,    70,   200,
+      72,    73,    74,     7,    -1,   317,    -1,    -1,    80,    -1,
+      -1,    -1,    -1,    85,    86,    -1,    -1,    -1,    -1,    -1,
+      -1,    93,    -1,    -1,    -1,    97,    98,    -1,    -1,    -1,
+     342,    -1,    -1,    -1,    38,    39,    40,    41,    42,    43,
+      44,    45,    -1,    -1,    -1,   357,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    65,    66,    -1,    -1,    69,    70,    -1,    72,    73,
+      74,    -1,    -1,    -1,    -1,    -1,    80,    -1,    -1,    -1,
+      -1,    85,    -1,    -1,    -1,    -1,   398,    -1,    -1,    93,
+      -1,    -1,    -1,    97,    98,     4,     5,     6,     7,     8,
+      -1,    10,    11,    12,    -1,    14,    15,    16,    -1,    18,
+      19,    20,    21,    22,    23,    24,    -1,    -1,    -1,    -1,
+      29,    30,    -1,     4,     5,     6,     7,     8,    -1,    10,
+      11,    12,    -1,    14,    15,    16,    -1,    18,    19,    20,
+      21,    22,    23,    24,    53,    -1,    55,    56,    29,    30,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    70,    -1,    -1,    -1,    -1,    -1,    -1,    77,    -1,
+      -1,    -1,    53,    -1,    55,    56,    -1,    -1,    87,    -1,
+      89,    90,    -1,    -1,    93,    -1,    -1,    -1,    -1,    70,
+      47,    48,    49,    50,    51,    52,    77,    -1,    -1,    47,
+      48,    49,    50,    51,    52,    -1,    87,    -1,    89,    -1,
+      -1,    -1,    93,    -1,    -1,    -1,    -1,    -1,    75,    -1,
+      77,    78,    79,    80,    81,    82,    83,    75,    -1,    77,
+      78,    79,    80,    81,    82,    83,    -1,    94,    -1,    -1,
+      -1,    -1,    90,    47,    48,    49,    50,    51,    52,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    47,    48,    49,
+      50,    51,    52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    75,    -1,    77,    78,    79,    80,    81,    82,    83,
+      -1,    -1,    -1,    -1,    -1,    75,    90,    77,    78,    79,
+      80,    81,    82,    83,    -1,    -1,    -1,    -1,    88,    47,
+      48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,    -1,
+      47,    48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,
+      47,    48,    49,    50,    51,    52,    -1,    75,    -1,    77,
+      78,    79,    80,    81,    82,    83,    -1,    -1,    75,    87,
+      77,    78,    79,    80,    81,    82,    83,    -1,    75,    86,
+      77,    78,    79,    80,    81,    82,    83,    -1,    -1,    86,
+      47,    48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,
+      47,    48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,
+      -1,    -1,    47,    48,    49,    50,    51,    52,    75,    -1,
+      77,    78,    79,    80,    81,    82,    83,    -1,    75,    86,
+      77,    78,    79,    80,    81,    82,    83,    -1,    -1,    86,
+      75,    76,    77,    78,    79,    80,    81,    82,    83,    47,
+      48,    49,    50,    51,    52,    -1,    -1,    -1,    49,    50,
+      51,    52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    75,    -1,    77,
+      78,    79,    80,    81,    82,    83,    77,    78,    79,    80,
+      81,    82,    83,     4,     5,     6,     7,     8,    -1,    10,
+      11,    12,    -1,    14,    15,    -1,    -1,    18,    19,    20,
+      21,    22
+};
+
+  /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
+     symbol of state STATE-NUM.  */
+static const unsigned char yystos[] =
+{
+       0,   100,     0,     3,     9,   101,   102,   103,    70,   178,
+     178,    89,   123,   124,   125,    85,   127,   104,   105,   109,
+     110,   122,   178,     4,     5,     6,     7,     8,    10,    11,
+      12,    14,    15,    16,    18,    19,    20,    21,    22,    23,
+      24,    29,    30,    53,    55,    56,    77,    87,    90,    93,
+     111,   112,   113,   114,   115,   116,   117,   120,   121,   124,
+     126,   128,   129,   130,   131,   132,   138,   139,   148,   150,
+     151,   152,   153,   158,   159,   160,   166,   168,   169,   170,
+     171,   174,   176,   178,    86,    87,    88,    76,    88,    85,
+      77,    85,    77,    85,    85,    85,    77,    77,    85,   142,
+       7,    38,    39,    40,    41,    42,    43,    44,    45,    65,
+      66,    69,    72,    73,    74,    80,    85,    97,    98,   161,
+     163,   164,   165,   168,   169,   170,   171,   176,   142,    85,
+     133,   133,    85,   124,    85,   166,   169,   178,   177,   122,
+     149,   178,    87,    87,    87,    87,    87,    87,    87,    87,
+      87,    51,    57,    58,    59,    60,    61,    62,    63,    64,
+      95,   155,    91,    59,    60,   156,    67,    85,    91,    93,
+     172,    76,   107,   108,   106,   109,   109,     7,   111,   178,
+     178,   113,   114,   117,   178,   113,   114,   117,   178,   178,
+     178,   117,   113,   114,   118,   178,    85,    93,   145,   146,
+     147,    85,   161,   113,   161,   161,   161,    47,    48,    49,
+      50,    51,    52,    75,    77,    78,    79,    80,    81,    82,
+      83,   133,   133,   145,   178,    85,   136,   136,   161,   162,
+      56,   162,    87,    91,    71,    95,   157,   161,    96,   154,
+     154,   157,   157,   178,    77,   175,    93,    86,   161,   173,
+     178,   161,   113,   115,    86,    88,    85,    86,    78,    78,
+      78,    86,    78,    78,    78,    86,    86,    86,    78,    88,
+      76,   161,   161,   124,   147,   146,   178,    86,    86,    97,
+     161,   161,   161,   161,   161,   161,   161,   161,   161,   161,
+     161,   161,   161,   161,    85,    89,    85,   124,    76,   162,
+     128,   128,    86,    85,    86,   166,   167,   178,    94,   157,
+     154,   178,   154,   172,   161,   154,   167,    88,    86,   172,
+      94,   107,   109,   178,    85,    85,    85,    91,    85,    85,
+      85,    85,   113,   114,   119,   178,    86,    94,    17,   140,
+      86,   161,    76,   161,   161,   161,    28,   141,   134,   169,
+     178,    86,   128,   162,   124,    88,    78,    87,    94,   173,
+      86,   178,   178,   178,   178,   178,   178,   178,   178,    78,
+      92,   143,   124,   147,   161,    86,    90,    86,   124,   147,
+      91,    79,    80,   135,   135,    54,    86,   167,   173,    86,
+      86,    86,    86,    86,    86,    86,    91,   124,    89,   124,
+      13,    31,    32,    33,    34,    35,    36,    37,   137,   128,
+      78,    31,   161,    85,    86,    26,    87,   144,    90,   178,
+     178,    86,    86
+};
+
+  /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
+static const unsigned char yyr1[] =
+{
+       0,    99,   100,   100,   101,   102,   102,   103,   103,   104,
+     104,   105,   105,   106,   106,   107,   107,   108,   108,   109,
+     110,   111,   111,   111,   111,   111,   111,   112,   113,   113,
+     113,   113,   113,   114,   114,   115,   115,   116,   116,   117,
+     117,   117,   117,   117,   117,   117,   117,   118,   118,   119,
+     119,   120,   121,   121,   121,   121,   121,   121,   121,   121,
+     121,   121,   121,   121,   122,   122,   123,   124,   125,   126,
+     127,   127,   128,   128,   128,   128,   128,   128,   128,   128,
+     128,   128,   128,   128,   128,   128,   128,   128,   129,   130,
+     131,   132,   132,   133,   134,   134,   135,   135,   135,   136,
+     136,   137,   137,   137,   137,   137,   137,   137,   137,   138,
+     139,   140,   140,   140,   141,   141,   141,   142,   143,   143,
+     144,   144,   145,   145,   145,   145,   145,   146,   147,   148,
+     148,   149,   150,   151,   151,   151,   152,   153,   154,   154,
+     155,   155,   155,   155,   155,   155,   156,   156,   157,   158,
+     158,   159,   159,   160,   160,   161,   161,   161,   161,   161,
+     161,   161,   161,   161,   161,   161,   161,   161,   161,   161,
+     161,   161,   161,   161,   161,   161,   161,   161,   161,   161,
+     161,   161,   161,   161,   161,   161,   161,   161,   162,   163,
+     163,   163,   163,   163,   163,   163,   164,   165,   165,   166,
+     166,   166,   167,   167,   168,   169,   169,   170,   171,   171,
+     171,   172,   172,   173,   173,   174,   175,   177,   176,   178
+};
+
+  /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
+static const unsigned char yyr2[] =
+{
+       0,     2,     0,     2,     2,     5,     7,     2,     2,     0,
+       1,     1,     3,     1,     3,     0,     1,     2,     2,     3,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     4,     1,     4,     1,     4,
+       1,     4,     1,     4,     1,     7,     4,     1,     1,     1,
+       1,     6,     7,     7,     7,     4,     4,     4,     7,     7,
+       7,     4,     4,     4,     1,     3,     1,     3,     1,     1,
+       0,     2,     2,     2,     1,     1,     1,     2,     2,     2,
+       1,     2,     1,     1,     2,     2,     2,     1,     1,     5,
+       6,     4,     4,     7,     2,     2,     0,     1,     1,     0,
+       3,     1,     1,     1,     1,     1,     1,     1,     4,     5,
+       5,     0,     3,     2,     0,     3,     2,    10,     0,     1,
+       1,     1,     0,     1,     1,     2,     2,     3,     3,     2,
+       4,     1,     3,     4,     3,     3,     4,     4,     0,     2,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     2,
+       1,     5,     7,     1,     5,     3,     3,     2,     2,     4,
+       8,     5,     5,     2,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     5,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     3,     1,     3,     6,     4,     4,     2,
+       4,     3,     2,     1,     3,     5,     5,     0,     4,     1
+};
+
+
+/* YYDPREC[RULE-NUM] -- Dynamic precedence of rule #RULE-NUM (0 if none).  */
+static const unsigned char yydprec[] =
+{
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0
+};
+
+/* YYMERGER[RULE-NUM] -- Index of merging function for rule #RULE-NUM.  */
+static const unsigned char yymerger[] =
+{
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0
+};
+
+/* YYIMMEDIATE[RULE-NUM] -- True iff rule #RULE-NUM is not to be deferred, as
+   in the case of predicates.  */
+static const yybool yyimmediate[] =
+{
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0
 };
 
 /* YYCONFLP[YYPACT[STATE-NUM]] -- Pointer into YYCONFL of start of
@@ -878,207 +957,38 @@ static const short int yyconfl[] =
        0,   213,     0,    96,     0,   151,     0
 };
 
-static const short int yycheck[] =
-{
-       3,     4,     6,    46,    16,   134,    90,    16,    92,    85,
-      86,    16,    15,    97,   199,    16,    90,     7,    92,   246,
-      26,    16,    70,    97,   226,   227,   317,    85,    89,    42,
-     157,    89,   116,    85,    46,   160,   161,    46,    85,     7,
-      44,    46,    88,    46,    91,    76,    93,    50,    88,    51,
-      18,    19,    20,    21,    22,    57,    58,    59,    60,    61,
-      62,    63,    64,    90,    85,    92,   357,    85,    89,    96,
-      38,    39,    40,    41,    42,    43,    44,    45,    86,    87,
-      70,    87,    85,    86,    77,    88,    89,   171,    91,    85,
-      93,    94,    95,    95,    77,    98,   225,    65,    66,    85,
-     302,    69,    70,    85,    72,    73,    74,   120,   121,   236,
-     235,    93,    80,    85,    91,   242,    93,    85,   245,    51,
-      52,    79,    80,    85,   243,    93,   129,    77,   355,    97,
-      98,   250,    86,    91,    88,    77,    47,    48,    49,    50,
-      51,    52,    81,    82,    83,    77,    78,    79,    80,    81,
-      82,    83,    85,   338,     0,    59,    60,     3,    85,   162,
-      85,   346,    85,     9,    75,   168,    77,    78,    79,    80,
-      81,    82,    83,    87,   303,    87,    10,    11,    12,   255,
-      14,    79,    80,   385,    87,   269,    97,    39,    13,   232,
-      87,    87,    87,    87,   198,   269,    87,    87,   201,    91,
-      67,    76,    85,   246,    85,    56,    31,    32,    33,    34,
-      35,    36,    37,    87,   226,   227,    71,   226,   227,   223,
-     232,   226,   227,   232,    95,   226,   227,   232,    96,   232,
-     233,   226,   227,    77,   246,   238,    93,   246,    85,    78,
-      78,   246,     5,   246,    47,    48,    49,    50,    51,    52,
-      86,    78,   255,   256,    86,    18,    19,    20,    21,    22,
-      78,    78,    78,   115,   116,   117,   118,   270,     5,    78,
-       7,    86,    75,    86,    77,    78,    79,    80,    81,    82,
-      83,    18,    19,    20,    21,    22,   298,    86,    88,    76,
-     302,    94,    85,   302,    86,   298,    93,   302,    76,   151,
-     304,   302,    79,    80,    81,    82,    83,   302,   160,   161,
-      85,    85,   355,    86,    86,   167,    85,   169,    94,    86,
-      85,   324,   325,   326,   327,   328,   329,   330,   331,    85,
-      85,    91,    85,    85,   338,    85,    85,    17,    86,    28,
-      86,    88,   346,   355,   196,   197,   355,    78,    86,    94,
-     355,    78,   355,    92,    54,   207,   208,   209,   210,   211,
-     212,   213,   214,   215,   216,   217,   218,   219,   220,   373,
-      91,    86,     5,   385,     7,   379,   385,    10,    11,    12,
-     385,    14,    86,   235,   385,    18,    19,    20,    21,    22,
-     385,    86,   244,    86,    86,     7,    86,    91,    86,    86,
-      78,    31,    85,    89,    47,    48,    49,    50,    51,    52,
-     413,    86,    86,    86,   417,    47,    87,    49,    50,    51,
-      52,   254,    50,   131,   350,   277,    38,    39,    40,    41,
-      42,    43,    44,    45,    77,    78,    79,    80,    81,    82,
-      83,   171,   294,   295,   296,    77,    78,    79,    80,    81,
-      82,    83,    40,    65,    66,    -1,   128,    69,    70,   200,
-      72,    73,    74,     7,    -1,   317,    -1,    -1,    80,    -1,
-      -1,    -1,    -1,    85,    86,    -1,    -1,    -1,    -1,    -1,
-      -1,    93,    -1,    -1,    -1,    97,    98,    -1,    -1,    -1,
-     342,    -1,    -1,    -1,    38,    39,    40,    41,    42,    43,
-      44,    45,    -1,    -1,    -1,   357,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    65,    66,    -1,    -1,    69,    70,    -1,    72,    73,
-      74,    -1,    -1,    -1,    -1,    -1,    80,    -1,    -1,    -1,
-      -1,    85,    -1,    -1,    -1,    -1,   398,    -1,    -1,    93,
-      -1,    -1,    -1,    97,    98,     4,     5,     6,     7,     8,
-      -1,    10,    11,    12,    -1,    14,    15,    16,    -1,    18,
-      19,    20,    21,    22,    23,    24,    -1,    -1,    -1,    -1,
-      29,    30,    -1,     4,     5,     6,     7,     8,    -1,    10,
-      11,    12,    -1,    14,    15,    16,    -1,    18,    19,    20,
-      21,    22,    23,    24,    53,    -1,    55,    56,    29,    30,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    70,    -1,    -1,    -1,    -1,    -1,    -1,    77,    -1,
-      -1,    -1,    53,    -1,    55,    56,    -1,    -1,    87,    -1,
-      89,    90,    -1,    -1,    93,    -1,    -1,    -1,    -1,    70,
-      47,    48,    49,    50,    51,    52,    77,    -1,    -1,    47,
-      48,    49,    50,    51,    52,    -1,    87,    -1,    89,    -1,
-      -1,    -1,    93,    -1,    -1,    -1,    -1,    -1,    75,    -1,
-      77,    78,    79,    80,    81,    82,    83,    75,    -1,    77,
-      78,    79,    80,    81,    82,    83,    -1,    94,    -1,    -1,
-      -1,    -1,    90,    47,    48,    49,    50,    51,    52,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    47,    48,    49,
-      50,    51,    52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    75,    -1,    77,    78,    79,    80,    81,    82,    83,
-      -1,    -1,    -1,    -1,    -1,    75,    90,    77,    78,    79,
-      80,    81,    82,    83,    -1,    -1,    -1,    -1,    88,    47,
-      48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,    -1,
-      47,    48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,
-      47,    48,    49,    50,    51,    52,    -1,    75,    -1,    77,
-      78,    79,    80,    81,    82,    83,    -1,    -1,    75,    87,
-      77,    78,    79,    80,    81,    82,    83,    -1,    75,    86,
-      77,    78,    79,    80,    81,    82,    83,    -1,    -1,    86,
-      47,    48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,
-      47,    48,    49,    50,    51,    52,    -1,    -1,    -1,    -1,
-      -1,    -1,    47,    48,    49,    50,    51,    52,    75,    -1,
-      77,    78,    79,    80,    81,    82,    83,    -1,    75,    86,
-      77,    78,    79,    80,    81,    82,    83,    -1,    -1,    86,
-      75,    76,    77,    78,    79,    80,    81,    82,    83,    47,
-      48,    49,    50,    51,    52,    -1,    -1,    -1,    49,    50,
-      51,    52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    75,    -1,    77,
-      78,    79,    80,    81,    82,    83,    77,    78,    79,    80,
-      81,    82,    83,     4,     5,     6,     7,     8,    -1,    10,
-      11,    12,    -1,    14,    15,    -1,    -1,    18,    19,    20,
-      21,    22
-};
-
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const unsigned char yystos[] =
-{
-       0,   100,     0,     3,     9,   101,   102,   103,    70,   178,
-     178,    89,   123,   124,   125,    85,   127,   104,   105,   109,
-     110,   122,   178,     4,     5,     6,     7,     8,    10,    11,
-      12,    14,    15,    16,    18,    19,    20,    21,    22,    23,
-      24,    29,    30,    53,    55,    56,    77,    87,    90,    93,
-     111,   112,   113,   114,   115,   116,   117,   120,   121,   124,
-     126,   128,   129,   130,   131,   132,   138,   139,   148,   150,
-     151,   152,   153,   158,   159,   160,   166,   168,   169,   170,
-     171,   174,   176,   178,    86,    87,    88,    76,    88,    85,
-      77,    85,    77,    85,    85,    85,    77,    77,    85,   142,
-       7,    38,    39,    40,    41,    42,    43,    44,    45,    65,
-      66,    69,    72,    73,    74,    80,    85,    97,    98,   161,
-     163,   164,   165,   168,   169,   170,   171,   176,   142,    85,
-     133,   133,    85,   124,    85,   166,   169,   178,   177,   122,
-     149,   178,    87,    87,    87,    87,    87,    87,    87,    87,
-      87,    51,    57,    58,    59,    60,    61,    62,    63,    64,
-      95,   155,    91,    59,    60,   156,    67,    85,    91,    93,
-     172,    76,   107,   108,   106,   109,   109,     7,   111,   178,
-     178,   113,   114,   117,   178,   113,   114,   117,   178,   178,
-     178,   117,   113,   114,   118,   178,    85,    93,   145,   146,
-     147,    85,   161,   113,   161,   161,   161,    47,    48,    49,
-      50,    51,    52,    75,    77,    78,    79,    80,    81,    82,
-      83,   133,   133,   145,   178,    85,   136,   136,   161,   162,
-      56,   162,    87,    91,    71,    95,   157,   161,    96,   154,
-     154,   157,   157,   178,    77,   175,    93,    86,   161,   173,
-     178,   161,   113,   115,    86,    88,    85,    86,    78,    78,
-      78,    86,    78,    78,    78,    86,    86,    86,    78,    88,
-      76,   161,   161,   124,   147,   146,   178,    86,    86,    97,
-     161,   161,   161,   161,   161,   161,   161,   161,   161,   161,
-     161,   161,   161,   161,    85,    89,    85,   124,    76,   162,
-     128,   128,    86,    85,    86,   166,   167,   178,    94,   157,
-     154,   178,   154,   172,   161,   154,   167,    88,    86,   172,
-      94,   107,   109,   178,    85,    85,    85,    91,    85,    85,
-      85,    85,   113,   114,   119,   178,    86,    94,    17,   140,
-      86,   161,    76,   161,   161,   161,    28,   141,   134,   169,
-     178,    86,   128,   162,   124,    88,    78,    87,    94,   173,
-      86,   178,   178,   178,   178,   178,   178,   178,   178,    78,
-      92,   143,   124,   147,   161,    86,    90,    86,   124,   147,
-      91,    79,    80,   135,   135,    54,    86,   167,   173,    86,
-      86,    86,    86,    86,    86,    86,    91,   124,    89,   124,
-      13,    31,    32,    33,    34,    35,    36,    37,   137,   128,
-      78,    31,   161,    85,    86,    26,    87,   144,    90,   178,
-     178,    86,    86
-};
-
-
-/* Prevent warning if -Wmissing-prototypes.  */
-int yyparse (void);
-
 /* Error token number */
 #define YYTERROR 1
+
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
    the previous symbol: RHS[0] (always defined).  */
 
-
-#define YYRHSLOC(Rhs, K) ((Rhs)[K].yystate.yyloc)
 #ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)				\
-    do									\
-      if (YYID (N))							\
-	{								\
-	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
-	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
-	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
-	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
-	}								\
-      else								\
-	{								\
-	  (Current).first_line   = (Current).last_line   =		\
-	    YYRHSLOC (Rhs, 0).last_line;				\
-	  (Current).first_column = (Current).last_column =		\
-	    YYRHSLOC (Rhs, 0).last_column;				\
-	}								\
-    while (YYID (0))
-
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
-
-# define YY_LOCATION_PRINT(File, Loc)			\
-    fprintf (File, "%d.%d-%d.%d",			\
-	     (Loc).first_line, (Loc).first_column,	\
-	     (Loc).last_line,  (Loc).last_column)
+# define YYLLOC_DEFAULT(Current, Rhs, N)                                \
+    do                                                                  \
+      if (N)                                                            \
+        {                                                               \
+          (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
+          (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
+          (Current).last_line    = YYRHSLOC (Rhs, N).last_line;         \
+          (Current).last_column  = YYRHSLOC (Rhs, N).last_column;       \
+        }                                                               \
+      else                                                              \
+        {                                                               \
+          (Current).first_line   = (Current).last_line   =              \
+            YYRHSLOC (Rhs, 0).last_line;                                \
+          (Current).first_column = (Current).last_column =              \
+            YYRHSLOC (Rhs, 0).last_column;                              \
+        }                                                               \
+    while (0)
 #endif
 
+# define YYRHSLOC(Rhs, K) ((Rhs)[K].yystate.yyloc)
 
-#ifndef YY_LOCATION_PRINT
-# define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-#define YYLEX yylex ()
 
 YYSTYPE yylval;
-
 YYLTYPE yylloc;
 
 int yynerrs;
@@ -1089,9 +999,12 @@ static const int YYEMPTY = -2;
 
 typedef enum { yyok, yyaccept, yyabort, yyerr } YYRESULTTAG;
 
-#define YYCHK(YYE)							     \
-   do { YYRESULTTAG yyflag = YYE; if (yyflag != yyok) return yyflag; }	     \
-   while (YYID (0))
+#define YYCHK(YYE)                              \
+  do {                                          \
+    YYRESULTTAG yychk_flag = YYE;               \
+    if (yychk_flag != yyok)                     \
+      return yychk_flag;                        \
+  } while (0)
 
 #if YYDEBUG
 
@@ -1099,35 +1012,71 @@ typedef enum { yyok, yyaccept, yyabort, yyerr } YYRESULTTAG;
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
+
+/* YY_LOCATION_PRINT -- Print the location on the stream.
+   This macro was not mandated originally: define only if we know
+   we won't break user code: when these are the locations we know.  */
+
+#ifndef YY_LOCATION_PRINT
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+
+/* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
+
+YY_ATTRIBUTE_UNUSED
+static unsigned
+yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
+{
+  unsigned res = 0;
+  int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
+  if (0 <= yylocp->first_line)
+    {
+      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
+      if (0 <= yylocp->first_column)
+        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
+    }
+  if (0 <= yylocp->last_line)
+    {
+      if (yylocp->first_line < yylocp->last_line)
+        {
+          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
+          if (0 <= end_col)
+            res += YYFPRINTF (yyo, ".%d", end_col);
+        }
+      else if (0 <= end_col && yylocp->first_column < end_col)
+        res += YYFPRINTF (yyo, "-%d", end_col);
+    }
+  return res;
+ }
+
+#  define YY_LOCATION_PRINT(File, Loc)          \
+  yy_location_print_ (File, &(Loc))
+
+# else
+#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
+# endif
+#endif
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+# define YYDPRINTF(Args)                        \
+  do {                                          \
+    if (yydebug)                                \
+      YYFPRINTF Args;                           \
+  } while (0)
 
-/*ARGSUSED*/
+
+/*----------------------------------------.
+| Print this symbol's value on YYOUTPUT.  |
+`----------------------------------------*/
+
 static void
 yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
 {
+  FILE *yyo = yyoutput;
+  YYUSE (yyo);
+  YYUSE (yylocationp);
   if (!yyvaluep)
     return;
-  YYUSE (yylocationp);
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
-# endif
-  switch (yytype)
-    {
-      default:
-	break;
-    }
+  YYUSE (yytype);
 }
 
 
@@ -1138,10 +1087,8 @@ yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvalue
 static void
 yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyoutput, "%s %s (",
+             yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
   YY_LOCATION_PRINT (yyoutput, *yylocationp);
   YYFPRINTF (yyoutput, ": ");
@@ -1149,20 +1096,25 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYL
   YYFPRINTF (yyoutput, ")");
 }
 
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			    \
-do {									    \
-  if (yydebug)								    \
-    {									    \
-      YYFPRINTF (stderr, "%s ", Title);					    \
-      yy_symbol_print (stderr, Type,					    \
-		       Value, Location);  \
-      YYFPRINTF (stderr, "\n");						    \
-    }									    \
-} while (YYID (0))
+# define YY_SYMBOL_PRINT(Title, Type, Value, Location)                  \
+  do {                                                                  \
+    if (yydebug)                                                        \
+      {                                                                 \
+        YYFPRINTF (stderr, "%s ", Title);                               \
+        yy_symbol_print (stderr, Type, Value, Location);        \
+        YYFPRINTF (stderr, "\n");                                       \
+      }                                                                 \
+  } while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
+
+struct yyGLRStack;
+static void yypstack (struct yyGLRStack* yystackp, size_t yyk)
+  YY_ATTRIBUTE_UNUSED;
+static void yypdumpstack (struct yyGLRStack* yystackp)
+  YY_ATTRIBUTE_UNUSED;
 
 #else /* !YYDEBUG */
 
@@ -1172,7 +1124,7 @@ int yydebug;
 #endif /* !YYDEBUG */
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1195,27 +1147,21 @@ int yydebug;
 #define YYHEADROOM 2
 
 #ifndef YYSTACKEXPANDABLE
-# if (! defined __cplusplus \
-      || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
-	  && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL))
 #  define YYSTACKEXPANDABLE 1
-# else
-#  define YYSTACKEXPANDABLE 0
-# endif
 #endif
 
 #if YYSTACKEXPANDABLE
-# define YY_RESERVE_GLRSTACK(Yystack)			\
-  do {							\
-    if (Yystack->yyspaceLeft < YYHEADROOM)		\
-      yyexpandGLRStack (Yystack);			\
-  } while (YYID (0))
+# define YY_RESERVE_GLRSTACK(Yystack)                   \
+  do {                                                  \
+    if (Yystack->yyspaceLeft < YYHEADROOM)              \
+      yyexpandGLRStack (Yystack);                       \
+  } while (0)
 #else
-# define YY_RESERVE_GLRSTACK(Yystack)			\
-  do {							\
-    if (Yystack->yyspaceLeft < YYHEADROOM)		\
-      yyMemoryExhausted (Yystack);			\
-  } while (YYID (0))
+# define YY_RESERVE_GLRSTACK(Yystack)                   \
+  do {                                                  \
+    if (Yystack->yyspaceLeft < YYHEADROOM)              \
+      yyMemoryExhausted (Yystack);                      \
+  } while (0)
 #endif
 
 
@@ -1258,27 +1204,27 @@ yytnamerr (char *yyres, const char *yystr)
       char const *yyp = yystr;
 
       for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            /* Fall through.  */
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
 
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
     do_not_strip_quotes: ;
     }
 
@@ -1298,7 +1244,7 @@ typedef int yyStateNum;
 typedef int yyRuleNum;
 
 /** Grammar symbol */
-typedef short int yySymbol;
+typedef int yySymbol;
 
 /** Item references, as in LALR(1) machine */
 typedef short int yyItemNum;
@@ -1319,7 +1265,7 @@ struct yyGLRState {
   yyStateNum yylrState;
   /** Preceding state in this stack */
   yyGLRState* yypred;
-  /** Source position of the first token produced by my symbol */
+  /** Source position of the last token produced by my symbol */
   size_t yyposn;
   union {
     /** First in a chain of alternative reductions producing the
@@ -1384,19 +1330,15 @@ struct yyGLRStack {
 static void yyexpandGLRStack (yyGLRStack* yystackp);
 #endif
 
-static void yyFail (yyGLRStack* yystackp, const char* yymsg)
-  __attribute__ ((__noreturn__));
-static void
+static _Noreturn void
 yyFail (yyGLRStack* yystackp, const char* yymsg)
 {
-  if (yymsg != NULL)
+  if (yymsg != YY_NULLPTR)
     yyerror (yymsg);
   YYLONGJMP (yystackp->yyexception_buffer, 1);
 }
 
-static void yyMemoryExhausted (yyGLRStack* yystackp)
-  __attribute__ ((__noreturn__));
-static void
+static _Noreturn void
 yyMemoryExhausted (yyGLRStack* yystackp)
 {
   YYLONGJMP (yystackp->yyexception_buffer, 2);
@@ -1417,18 +1359,24 @@ yytokenName (yySymbol yytoken)
 /** Fill in YYVSP[YYLOW1 .. YYLOW0-1] from the chain of states starting
  *  at YYVSP[YYLOW0].yystate.yypred.  Leaves YYVSP[YYLOW1].yystate.yypred
  *  containing the pointer to the next state in the chain.  */
-static void yyfillin (yyGLRStackItem *, int, int) __attribute__ ((__unused__));
+static void yyfillin (yyGLRStackItem *, int, int) YY_ATTRIBUTE_UNUSED;
 static void
 yyfillin (yyGLRStackItem *yyvsp, int yylow0, int yylow1)
 {
-  yyGLRState* s;
   int i;
-  s = yyvsp[yylow0].yystate.yypred;
+  yyGLRState *s = yyvsp[yylow0].yystate.yypred;
   for (i = yylow0-1; i >= yylow1; i -= 1)
     {
-      YYASSERT (s->yyresolved);
-      yyvsp[i].yystate.yyresolved = yytrue;
-      yyvsp[i].yystate.yysemantics.yysval = s->yysemantics.yysval;
+#if YYDEBUG
+      yyvsp[i].yystate.yylrState = s->yylrState;
+#endif
+      yyvsp[i].yystate.yyresolved = s->yyresolved;
+      if (s->yyresolved)
+        yyvsp[i].yystate.yysemantics.yysval = s->yysemantics.yysval;
+      else
+        /* The effect of using yysval or yyloc (in an immediate rule) is
+         * undefined.  */
+        yyvsp[i].yystate.yysemantics.yyfirstVal = YY_NULLPTR;
       yyvsp[i].yystate.yyloc = s->yyloc;
       s = yyvsp[i].yystate.yypred = s->yypred;
     }
@@ -1438,7 +1386,7 @@ yyfillin (yyGLRStackItem *yyvsp, int yylow0, int yylow1)
  * YYVSP[YYLOW1 .. *YYLOW-1] as in yyfillin and set *YYLOW = YYLOW1.
  * For convenience, always return YYLOW1.  */
 static inline int yyfill (yyGLRStackItem *, int *, int, yybool)
-     __attribute__ ((__unused__));
+     YY_ATTRIBUTE_UNUSED;
 static inline int
 yyfill (yyGLRStackItem *yyvsp, int *yylow, int yylow1, yybool yynormal)
 {
@@ -1455,16 +1403,16 @@ yyfill (yyGLRStackItem *yyvsp, int *yylow, int yylow1, yybool yynormal)
  *  value ($$), and yylocp points to place for location information
  *  (@$).  Returns yyok for normal return, yyaccept for YYACCEPT,
  *  yyerr for YYERROR, yyabort for YYABORT.  */
-/*ARGSUSED*/ static YYRESULTTAG
-yyuserAction (yyRuleNum yyn, int yyrhslen, yyGLRStackItem* yyvsp,
-	      YYSTYPE* yyvalp,
-	      YYLTYPE* YYOPTIONAL_LOC (yylocp),
-	      yyGLRStack* yystackp
-	      )
+static YYRESULTTAG
+yyuserAction (yyRuleNum yyn, size_t yyrhslen, yyGLRStackItem* yyvsp,
+              yyGLRStack* yystackp,
+              YYSTYPE* yyvalp, YYLTYPE *yylocp)
 {
-  yybool yynormal __attribute__ ((__unused__)) =
-    (yystackp->yysplitPoint == NULL);
+  yybool yynormal YY_ATTRIBUTE_UNUSED = (yystackp->yysplitPoint == YY_NULLPTR);
   int yylow;
+  YYUSE (yyvalp);
+  YYUSE (yylocp);
+  YYUSE (yyrhslen);
 # undef yyerrok
 # define yyerrok (yystackp->yyerrState = 0)
 # undef YYACCEPT
@@ -1480,9 +1428,9 @@ yyuserAction (yyRuleNum yyn, int yyrhslen, yyGLRStackItem* yyvsp,
 # undef YYFILL
 # define YYFILL(N) yyfill (yyvsp, &yylow, N, yynormal)
 # undef YYBACKUP
-# define YYBACKUP(Token, Value)						     \
+# define YYBACKUP(Token, Value)                                              \
   return yyerror (YY_("syntax error: cannot back up")),     \
-	 yyerrok, yyerr
+         yyerrok, yyerr
 
   yylow = 1;
   if (yyrhslen == 0)
@@ -1495,1485 +1443,1275 @@ yyuserAction (yyRuleNum yyn, int yyrhslen, yyGLRStackItem* yyvsp,
   switch (yyn)
     {
         case 4:
-
-/* Line 936 of glr.c  */
-#line 104 "parse/gm_grammer.y"
-    {GM_procdef_finish();;}
+#line 104 "parse/gm_grammer.y" /* glr.c:816  */
+    {GM_procdef_finish();}
+#line 1449 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 7:
-
-/* Line 936 of glr.c  */
-#line 109 "parse/gm_grammer.y"
-    { GM_procdef_begin((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr), false);  ;}
+#line 109 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_begin((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), false);  }
+#line 1455 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 8:
-
-/* Line 936 of glr.c  */
-#line 110 "parse/gm_grammer.y"
-    { GM_procdef_begin((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr), true);  ;}
+#line 110 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_begin((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), true);  }
+#line 1461 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 11:
-
-/* Line 936 of glr.c  */
-#line 115 "parse/gm_grammer.y"
-    { GM_procdef_add_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr)); ;}
+#line 115 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_add_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); }
+#line 1467 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 12:
-
-/* Line 936 of glr.c  */
-#line 116 "parse/gm_grammer.y"
-    { GM_procdef_add_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr)); ;}
+#line 116 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_add_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); }
+#line 1473 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 13:
-
-/* Line 936 of glr.c  */
-#line 119 "parse/gm_grammer.y"
-    { GM_procdef_add_out_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr)); ;}
+#line 119 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_add_out_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); }
+#line 1479 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 14:
-
-/* Line 936 of glr.c  */
-#line 120 "parse/gm_grammer.y"
-    { GM_procdef_add_out_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr)); ;}
+#line 120 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_add_out_argdecl((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); }
+#line 1485 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 17:
-
-/* Line 936 of glr.c  */
-#line 125 "parse/gm_grammer.y"
-    { GM_procdef_return_type((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr));;}
+#line 125 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_return_type((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 1491 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 18:
-
-/* Line 936 of glr.c  */
-#line 126 "parse/gm_grammer.y"
-    { GM_procdef_return_type((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr));;}
+#line 126 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_return_type((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 1497 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 19:
-
-/* Line 936 of glr.c  */
-#line 130 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_procdef_arg((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr));;}
+#line 130 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_procdef_arg((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 1503 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 20:
-
-/* Line 936 of glr.c  */
-#line 132 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_finish_id_comma_list();;}
+#line 132 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_finish_id_comma_list();}
+#line 1509 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 21:
-
-/* Line 936 of glr.c  */
-#line 134 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 134 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1515 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 22:
-
-/* Line 936 of glr.c  */
-#line 135 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 135 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1521 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 23:
-
-/* Line 936 of glr.c  */
-#line 136 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 136 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1527 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 24:
-
-/* Line 936 of glr.c  */
-#line 137 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 137 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1533 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 25:
-
-/* Line 936 of glr.c  */
-#line 138 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 138 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1539 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 26:
-
-/* Line 936 of glr.c  */
-#line 139 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 139 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1545 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 27:
-
-/* Line 936 of glr.c  */
-#line 142 "parse/gm_grammer.y"
+#line 142 "parse/gm_grammer.y" /* glr.c:816  */
     { ((*yyvalp).ptr) = GM_graphtype_ref(GMTYPE_GRAPH); 
-                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1552 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 28:
-
-/* Line 936 of glr.c  */
-#line 145 "parse/gm_grammer.y"
+#line 145 "parse/gm_grammer.y" /* glr.c:816  */
     { ((*yyvalp).ptr) = GM_primtype_ref(GMTYPE_INT);
-                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1559 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 29:
-
-/* Line 936 of glr.c  */
-#line 147 "parse/gm_grammer.y"
+#line 147 "parse/gm_grammer.y" /* glr.c:816  */
     { ((*yyvalp).ptr) = GM_primtype_ref(GMTYPE_LONG);
-                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1566 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 30:
-
-/* Line 936 of glr.c  */
-#line 149 "parse/gm_grammer.y"
+#line 149 "parse/gm_grammer.y" /* glr.c:816  */
     { ((*yyvalp).ptr) = GM_primtype_ref(GMTYPE_FLOAT);
-                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1573 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 31:
-
-/* Line 936 of glr.c  */
-#line 151 "parse/gm_grammer.y"
+#line 151 "parse/gm_grammer.y" /* glr.c:816  */
     { ((*yyvalp).ptr) = GM_primtype_ref(GMTYPE_DOUBLE);
-                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1580 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 32:
-
-/* Line 936 of glr.c  */
-#line 153 "parse/gm_grammer.y"
+#line 153 "parse/gm_grammer.y" /* glr.c:816  */
     { ((*yyvalp).ptr) = GM_primtype_ref(GMTYPE_BOOL);
-                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+                   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1587 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 33:
-
-/* Line 936 of glr.c  */
-#line 156 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 156 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1593 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 34:
-
-/* Line 936 of glr.c  */
-#line 157 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 157 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1599 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 35:
-
-/* Line 936 of glr.c  */
-#line 159 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr));   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 159 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr));   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1605 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 36:
-
-/* Line 936 of glr.c  */
-#line 160 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodetype_ref(NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 160 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodetype_ref(NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1611 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 37:
-
-/* Line 936 of glr.c  */
-#line 161 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr));   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 161 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr));   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1617 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 38:
-
-/* Line 936 of glr.c  */
-#line 162 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgetype_ref(NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 162 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgetype_ref(NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1623 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 39:
-
-/* Line 936 of glr.c  */
-#line 164 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSET, (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr));     GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 164 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSET, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr));     GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1629 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 40:
-
-/* Line 936 of glr.c  */
-#line 165 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSET, NULL);   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 165 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSET, NULL);   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1635 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 41:
-
-/* Line 936 of glr.c  */
-#line 167 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSEQ, (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr));     GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 167 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSEQ, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr));     GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1641 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 42:
-
-/* Line 936 of glr.c  */
-#line 168 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSEQ, NULL);   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 168 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NSEQ, NULL);   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1647 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 43:
-
-/* Line 936 of glr.c  */
-#line 170 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NORDER, (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr));   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 170 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NORDER, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr));   GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1653 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 44:
-
-/* Line 936 of glr.c  */
-#line 171 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NORDER, NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 171 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_settype_ref(GMTYPE_NORDER, NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 1659 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 45:
-
-/* Line 936 of glr.c  */
-#line 173 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_queuetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.ptr)); 	  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_column);;}
+#line 173 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_queuetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr)); 	  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_column);}
+#line 1665 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 46:
-
-/* Line 936 of glr.c  */
-#line 174 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_queuetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), NULL);  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 174 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_queuetype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL);  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1671 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 47:
-
-/* Line 936 of glr.c  */
-#line 176 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 176 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 1677 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 48:
-
-/* Line 936 of glr.c  */
-#line 177 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 177 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 1683 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 49:
-
-/* Line 936 of glr.c  */
-#line 179 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 179 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 1689 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 50:
-
-/* Line 936 of glr.c  */
-#line 180 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 180 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 1695 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 51:
-
-/* Line 936 of glr.c  */
-#line 182 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_maptype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (6))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (6))].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (6))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (6))].yystate.yyloc).first_column); ;}
+#line 182 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_maptype_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-5)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-5)].yystate.yyloc).first_column); }
+#line 1701 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 52:
-
-/* Line 936 of glr.c  */
-#line 185 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.ptr) ); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_column);;}
+#line 185 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr) ); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_column);}
+#line 1707 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 53:
-
-/* Line 936 of glr.c  */
-#line 186 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.ptr) ); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_column);;}
+#line 186 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr) ); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_column);}
+#line 1713 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 54:
-
-/* Line 936 of glr.c  */
-#line 187 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.ptr) ); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_column);;}
+#line 187 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr) ); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_column);}
+#line 1719 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 55:
-
-/* Line 936 of glr.c  */
-#line 188 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 188 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1725 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 56:
-
-/* Line 936 of glr.c  */
-#line 189 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 189 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1731 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 57:
-
-/* Line 936 of glr.c  */
-#line 190 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 190 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_nodeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1737 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 58:
-
-/* Line 936 of glr.c  */
-#line 192 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_column);;}
+#line 192 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_column);}
+#line 1743 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 59:
-
-/* Line 936 of glr.c  */
-#line 193 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_column);;}
+#line 193 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_column);}
+#line 1749 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 60:
-
-/* Line 936 of glr.c  */
-#line 194 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (7))].yystate.yyloc).first_column);;}
+#line 194 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yyloc).first_column);}
+#line 1755 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 61:
-
-/* Line 936 of glr.c  */
-#line 195 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 195 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1761 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 62:
-
-/* Line 936 of glr.c  */
-#line 196 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 196 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1767 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 63:
-
-/* Line 936 of glr.c  */
-#line 197 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 197 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_edgeprop_ref((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1773 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 64:
-
-/* Line 936 of glr.c  */
-#line 199 "parse/gm_grammer.y"
-    { GM_add_id_comma_list((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr));;}
+#line 199 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_add_id_comma_list((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 1779 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 65:
-
-/* Line 936 of glr.c  */
-#line 200 "parse/gm_grammer.y"
-    { GM_add_id_comma_list((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr));;}
+#line 200 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_add_id_comma_list((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 1785 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 66:
-
-/* Line 936 of glr.c  */
-#line 203 "parse/gm_grammer.y"
-    { GM_procdef_setbody((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr)); ;}
+#line 203 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_procdef_setbody((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); }
+#line 1791 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 67:
-
-/* Line 936 of glr.c  */
-#line 205 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_finish_sentblock(); ;}
+#line 205 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_finish_sentblock(); }
+#line 1797 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 68:
-
-/* Line 936 of glr.c  */
-#line 206 "parse/gm_grammer.y"
-    { GM_start_sentblock(); ;}
+#line 206 "parse/gm_grammer.y" /* glr.c:816  */
+    { GM_start_sentblock(); }
+#line 1803 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 71:
-
-/* Line 936 of glr.c  */
-#line 210 "parse/gm_grammer.y"
-    { if ((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr)!=NULL) GM_add_sent((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr)); ;}
+#line 210 "parse/gm_grammer.y" /* glr.c:816  */
+    { if ((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)!=NULL) GM_add_sent((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); }
+#line 1809 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 72:
-
-/* Line 936 of glr.c  */
-#line 212 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 212 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1815 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 73:
-
-/* Line 936 of glr.c  */
-#line 213 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 213 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1821 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 74:
-
-/* Line 936 of glr.c  */
-#line 214 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 214 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1827 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 75:
-
-/* Line 936 of glr.c  */
-#line 215 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 215 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1833 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 76:
-
-/* Line 936 of glr.c  */
-#line 216 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 216 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1839 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 77:
-
-/* Line 936 of glr.c  */
-#line 217 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 217 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1845 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 78:
-
-/* Line 936 of glr.c  */
-#line 218 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 218 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1851 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 79:
-
-/* Line 936 of glr.c  */
-#line 219 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 219 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1857 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 80:
-
-/* Line 936 of glr.c  */
-#line 220 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 220 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1863 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 81:
-
-/* Line 936 of glr.c  */
-#line 221 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 221 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1869 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 82:
-
-/* Line 936 of glr.c  */
-#line 222 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 222 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1875 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 83:
-
-/* Line 936 of glr.c  */
-#line 223 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 223 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 1881 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 84:
-
-/* Line 936 of glr.c  */
-#line 224 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 224 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1887 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 85:
-
-/* Line 936 of glr.c  */
-#line 225 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 225 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1893 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 86:
-
-/* Line 936 of glr.c  */
-#line 226 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 226 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 1899 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 87:
-
-/* Line 936 of glr.c  */
-#line 227 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = NULL;;}
+#line 227 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = NULL;}
+#line 1905 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 88:
-
-/* Line 936 of glr.c  */
-#line 229 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_new_call_sent((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr), true);;}
+#line 229 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_new_call_sent((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), true);}
+#line 1911 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 89:
-
-/* Line 936 of glr.c  */
-#line 231 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_while((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (5))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (5))].yystate.yysemantics.yysval.ptr));;}
+#line 231 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_while((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 1917 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 90:
-
-/* Line 936 of glr.c  */
-#line 233 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_dowhile((((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (6))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (6))].yystate.yysemantics.yysval.ptr)); ;}
+#line 233 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_dowhile((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr)); }
+#line 1923 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 91:
-
-/* Line 936 of glr.c  */
-#line 236 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_foreach((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), false, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).b1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).b2); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 236 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_foreach((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), false, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).b1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).b2); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1929 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 92:
-
-/* Line 936 of glr.c  */
-#line 237 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_foreach((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), true, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).b1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.pair).b2); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column);;}
+#line 237 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_foreach((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), true, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).b1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).b2); GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 1935 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 93:
-
-/* Line 936 of glr.c  */
-#line 245 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (7))].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (7))].yystate.yysemantics.yysval.pair).p1; ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (7))].yystate.yysemantics.yysval.pair).b1; ((*yyvalp).pair).i1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.pair).i1; ((*yyvalp).pair).p3 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (7))].yystate.yysemantics.yysval.pair).p1; ((*yyvalp).pair).b2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (7))].yystate.yysemantics.yysval.pair).b2; ;}
+#line 245 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-5)].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p1; ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).b1; ((*yyvalp).pair).i1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.pair).i1; ((*yyvalp).pair).p3 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.pair).p1; ((*yyvalp).pair).b2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).b2; }
+#line 1941 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 94:
-
-/* Line 936 of glr.c  */
-#line 247 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.bval); ((*yyvalp).pair).b2 = false;;}
+#line 247 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.bval); ((*yyvalp).pair).b2 = false;}
+#line 1947 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 95:
-
-/* Line 936 of glr.c  */
-#line 248 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.bval); ((*yyvalp).pair).b2 = true;;}
+#line 248 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.bval); ((*yyvalp).pair).b2 = true;}
+#line 1953 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 96:
-
-/* Line 936 of glr.c  */
-#line 250 "parse/gm_grammer.y"
-    { ((*yyvalp).bval) = false;;}
+#line 250 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).bval) = false;}
+#line 1959 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 97:
-
-/* Line 936 of glr.c  */
-#line 251 "parse/gm_grammer.y"
-    { ((*yyvalp).bval) = true;;}
+#line 251 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).bval) = true;}
+#line 1965 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 98:
-
-/* Line 936 of glr.c  */
-#line 252 "parse/gm_grammer.y"
-    { ((*yyvalp).bval) = false;;}
+#line 252 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).bval) = false;}
+#line 1971 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 99:
-
-/* Line 936 of glr.c  */
-#line 254 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = NULL;;}
+#line 254 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = NULL;}
+#line 1977 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 100:
-
-/* Line 936 of glr.c  */
-#line 255 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.ptr); ;}
+#line 255 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr); }
+#line 1983 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 101:
-
-/* Line 936 of glr.c  */
-#line 257 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_NODE_ALL; ((*yyvalp).pair).p1=NULL;;}
+#line 257 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_NODE_ALL; ((*yyvalp).pair).p1=NULL;}
+#line 1989 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 102:
-
-/* Line 936 of glr.c  */
-#line 258 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_EDGE_ALL; ((*yyvalp).pair).p1=NULL;;}
+#line 258 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_EDGE_ALL; ((*yyvalp).pair).p1=NULL;}
+#line 1995 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 103:
-
-/* Line 936 of glr.c  */
-#line 259 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_NODE_NBRS; ((*yyvalp).pair).p1=NULL;;}
+#line 259 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_NODE_NBRS; ((*yyvalp).pair).p1=NULL;}
+#line 2001 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 104:
-
-/* Line 936 of glr.c  */
-#line 260 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_NODE_IN_NBRS; ((*yyvalp).pair).p1=NULL;;}
+#line 260 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_NODE_IN_NBRS; ((*yyvalp).pair).p1=NULL;}
+#line 2007 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 105:
-
-/* Line 936 of glr.c  */
-#line 261 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_NODE_UP_NBRS; ((*yyvalp).pair).p1=NULL;;}
+#line 261 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_NODE_UP_NBRS; ((*yyvalp).pair).p1=NULL;}
+#line 2013 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 106:
-
-/* Line 936 of glr.c  */
-#line 262 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_NODE_DOWN_NBRS;((*yyvalp).pair).p1=NULL;;}
+#line 262 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_NODE_DOWN_NBRS;((*yyvalp).pair).p1=NULL;}
+#line 2019 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 107:
-
-/* Line 936 of glr.c  */
-#line 263 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_ANY;((*yyvalp).pair).p1=NULL; /* should be resolved after typechecking */;}
+#line 263 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_ANY;((*yyvalp).pair).p1=NULL; /* should be resolved after typechecking */}
+#line 2025 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 108:
-
-/* Line 936 of glr.c  */
-#line 264 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).i1 = GMITER_NODE_COMMON_NBRS;((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr); ;}
+#line 264 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).i1 = GMITER_NODE_COMMON_NBRS;((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr); }
+#line 2031 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 109:
-
-/* Line 936 of glr.c  */
-#line 267 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_bfs( (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p2,(((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p3,  (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (5))].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (5))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (5))].yystate.yysemantics.yysval.pair).p2,   (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (5))].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (5))].yystate.yysemantics.yysval.pair).p1,   (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).b1, false); 
-                  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_column);;}
+#line 267 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_bfs( (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p2,(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p3,  (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).p2,   (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).p1,   (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).b1, false); 
+                  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_column);}
+#line 2038 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 110:
-
-/* Line 936 of glr.c  */
-#line 271 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_bfs( (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p2,(((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p3,  (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (5))].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (5))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (5))].yystate.yysemantics.yysval.pair).p2,   (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (5))].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (5))].yystate.yysemantics.yysval.pair).p1,   (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).b1, true); 
-                  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_column);;}
+#line 271 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_bfs( (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p2,(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p3,  (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p1,(((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).p2,   (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).p1,   (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).b1, true); 
+                  GM_set_lineinfo(((*yyvalp).ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_column);}
+#line 2045 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 111:
-
-/* Line 936 of glr.c  */
-#line 274 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = NULL;;}
+#line 274 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = NULL;}
+#line 2051 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 112:
-
-/* Line 936 of glr.c  */
-#line 275 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.ptr);  ;}
+#line 275 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);  }
+#line 2057 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 113:
-
-/* Line 936 of glr.c  */
-#line 276 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = NULL;  ;}
+#line 276 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = NULL;  }
+#line 2063 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 114:
-
-/* Line 936 of glr.c  */
-#line 278 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = NULL;;}
+#line 278 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = NULL;}
+#line 2069 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 115:
-
-/* Line 936 of glr.c  */
-#line 279 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.ptr);  ;}
+#line 279 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);  }
+#line 2075 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 116:
-
-/* Line 936 of glr.c  */
-#line 280 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = NULL;  ;}
+#line 280 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = NULL;  }
+#line 2081 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 117:
-
-/* Line 936 of glr.c  */
-#line 282 "parse/gm_grammer.y"
+#line 282 "parse/gm_grammer.y" /* glr.c:816  */
     {
-                           ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (10))].yystate.yysemantics.yysval.ptr); // it
-                           ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (10))].yystate.yysemantics.yysval.ptr); // source
-                           ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (10))].yystate.yysemantics.yysval.bval); // optional tp
-                           ((*yyvalp).pair).p3 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((9) - (10))].yystate.yysemantics.yysval.ptr); // source
-                       ;}
+                           ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-8)].yystate.yysemantics.yysval.ptr); // it
+                           ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yysemantics.yysval.ptr); // source
+                           ((*yyvalp).pair).b1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-5)].yystate.yysemantics.yysval.bval); // optional tp
+                           ((*yyvalp).pair).p3 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr); // source
+                       }
+#line 2092 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 118:
-
-/* Line 936 of glr.c  */
-#line 289 "parse/gm_grammer.y"
-    {((*yyvalp).bval) = false;;}
+#line 289 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).bval) = false;}
+#line 2098 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 119:
-
-/* Line 936 of glr.c  */
-#line 290 "parse/gm_grammer.y"
-    {((*yyvalp).bval) = true;;}
+#line 290 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).bval) = true;}
+#line 2104 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 120:
-
-/* Line 936 of glr.c  */
-#line 292 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = 0;;}
+#line 292 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = 0;}
+#line 2110 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 121:
-
-/* Line 936 of glr.c  */
-#line 293 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = 0;;}
+#line 293 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = 0;}
+#line 2116 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 122:
-
-/* Line 936 of glr.c  */
-#line 296 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = NULL;;}
+#line 296 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = NULL;}
+#line 2122 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 123:
-
-/* Line 936 of glr.c  */
-#line 297 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = NULL;;}
+#line 297 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = NULL;}
+#line 2128 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 124:
-
-/* Line 936 of glr.c  */
-#line 298 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 298 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = NULL; ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 2134 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 125:
-
-/* Line 936 of glr.c  */
-#line 299 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 299 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 2140 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 126:
-
-/* Line 936 of glr.c  */
-#line 300 "parse/gm_grammer.y"
-    {((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr);;}
+#line 300 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).pair).p2 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);   ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 2146 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 127:
-
-/* Line 936 of glr.c  */
-#line 302 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.ptr);;}
+#line 302 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 2152 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 128:
-
-/* Line 936 of glr.c  */
-#line 304 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.ptr);;}
+#line 304 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 2158 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 129:
-
-/* Line 936 of glr.c  */
-#line 307 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) =  GM_vardecl_prim((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr)); ;}
+#line 307 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) =  GM_vardecl_prim((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); }
+#line 2164 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 130:
-
-/* Line 936 of glr.c  */
-#line 308 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) =  GM_vardecl_and_assign((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.ptr));;}
+#line 308 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) =  GM_vardecl_and_assign((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr),(((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 2170 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 131:
-
-/* Line 936 of glr.c  */
-#line 310 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_finish_id_comma_list();;}
+#line 310 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_finish_id_comma_list();}
+#line 2176 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 132:
-
-/* Line 936 of glr.c  */
-#line 312 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_normal_assign((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);}
+#line 312 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_normal_assign((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2182 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 133:
-
-/* Line 936 of glr.c  */
-#line 313 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_reduce_assign((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.ival)); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yyloc).first_column);;}
+#line 313 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_reduce_assign((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ival)); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_column);}
+#line 2188 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 134:
-
-/* Line 936 of glr.c  */
-#line 314 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_reduce_assign((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), GM_expr_ival(1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMREDUCE_PLUS); ;}
+#line 314 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_reduce_assign((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), GM_expr_ival(1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMREDUCE_PLUS); }
+#line 2194 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 135:
-
-/* Line 936 of glr.c  */
-#line 315 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_reduce_assign((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), GM_expr_ival(-1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMREDUCE_PLUS); ;}
+#line 315 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_reduce_assign((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), GM_expr_ival(-1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMREDUCE_PLUS); }
+#line 2200 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 136:
-
-/* Line 936 of glr.c  */
-#line 317 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_defer_assign((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yyloc).first_column);;}
+#line 317 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_defer_assign((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr)); GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_column);}
+#line 2206 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 137:
-
-/* Line 936 of glr.c  */
-#line 319 "parse/gm_grammer.y"
+#line 319 "parse/gm_grammer.y" /* glr.c:816  */
     {
-                                  ((*yyvalp).ptr) = GM_argminmax_assign((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.pair).l_list, (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.pair).e_list);
-                                  GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yyloc).first_column);
-                              ;}
+                                  ((*yyvalp).ptr) = GM_argminmax_assign((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).l_list, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.pair).e_list);
+                                  GM_set_lineinfo(((*yyvalp).ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_column);
+                              }
+#line 2215 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 138:
-
-/* Line 936 of glr.c  */
-#line 324 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = NULL; ;}
+#line 324 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = NULL; }
+#line 2221 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 139:
-
-/* Line 936 of glr.c  */
-#line 325 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr);   ;}
+#line 325 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);   }
+#line 2227 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 140:
-
-/* Line 936 of glr.c  */
-#line 327 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_PLUS;;}
+#line 327 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_PLUS;}
+#line 2233 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 141:
-
-/* Line 936 of glr.c  */
-#line 328 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MULT;;}
+#line 328 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MULT;}
+#line 2239 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 142:
-
-/* Line 936 of glr.c  */
-#line 329 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MIN;;}
+#line 329 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MIN;}
+#line 2245 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 143:
-
-/* Line 936 of glr.c  */
-#line 330 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MAX;;}
+#line 330 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MAX;}
+#line 2251 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 144:
-
-/* Line 936 of glr.c  */
-#line 331 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_AND;;}
+#line 331 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_AND;}
+#line 2257 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 145:
-
-/* Line 936 of glr.c  */
-#line 332 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_OR;;}
+#line 332 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_OR;}
+#line 2263 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 146:
-
-/* Line 936 of glr.c  */
-#line 334 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MIN;;}
+#line 334 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MIN;}
+#line 2269 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 147:
-
-/* Line 936 of glr.c  */
-#line 335 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MAX;;}
+#line 335 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MAX;}
+#line 2275 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 148:
-
-/* Line 936 of glr.c  */
-#line 337 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 337 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 2281 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 149:
-
-/* Line 936 of glr.c  */
-#line 340 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_return ((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_column) ;;}
+#line 340 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_return ((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column) ;}
+#line 2287 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 150:
-
-/* Line 936 of glr.c  */
-#line 341 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_return (NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 341 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_return (NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 2293 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 151:
-
-/* Line 936 of glr.c  */
-#line 346 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_if((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (5))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (5))].yystate.yysemantics.yysval.ptr), NULL);;}
+#line 346 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_if((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), NULL);}
+#line 2299 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 152:
-
-/* Line 936 of glr.c  */
-#line 347 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_if((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (7))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((7) - (7))].yystate.yysemantics.yysval.ptr));;}
+#line 347 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_if((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 2305 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 153:
-
-/* Line 936 of glr.c  */
-#line 350 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) =  GM_foreign_sent((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr));;}
+#line 350 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) =  GM_foreign_sent((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 2311 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 154:
-
-/* Line 936 of glr.c  */
-#line 351 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) =  GM_foreign_sent_mut((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (5))].yystate.yysemantics.yysval.l_list));;}
+#line 351 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) =  GM_foreign_sent_mut((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.l_list));}
+#line 2317 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 155:
-
-/* Line 936 of glr.c  */
-#line 354 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.ptr);;}
+#line 354 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr);}
+#line 2323 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 156:
-
-/* Line 936 of glr.c  */
-#line 355 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_uop((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.ptr), GMOP_ABS, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yyloc).first_column); ;}
+#line 355 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_uop((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), GMOP_ABS, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yyloc).first_column); }
+#line 2329 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 157:
-
-/* Line 936 of glr.c  */
-#line 357 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_uop((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr), GMOP_NEG, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_column); ;}
+#line 357 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_uop((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_NEG, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column); }
+#line 2335 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 158:
-
-/* Line 936 of glr.c  */
-#line 358 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_luop((((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.ptr), GMOP_NOT, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_column); ;}
+#line 358 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_luop((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_NOT, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column); }
+#line 2341 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 159:
-
-/* Line 936 of glr.c  */
-#line 359 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_conversion((((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (4))].yystate.yysemantics.yysval.ptr) , (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yyloc).first_column); ;}
+#line 359 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_conversion((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr) , (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column); }
+#line 2347 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 160:
-
-/* Line 936 of glr.c  */
-#line 360 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (8))].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (8))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (8))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (8))].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((7) - (8))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (8))].yystate.yysemantics.yysval.ptr),   (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (8))].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (8))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (8))].yystate.yyloc).first_column, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (8))].yystate.yysemantics.yysval.pair).b2);;}
+#line 360 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL (-7)].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr),   (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL (-7)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-7)].yystate.yyloc).first_column, (((yyGLRStackItem const *)yyvsp)[YYFILL (-6)].yystate.yysemantics.yysval.pair).b2);}
+#line 2353 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 161:
-
-/* Line 936 of glr.c  */
-#line 361 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (5))].yystate.yysemantics.yysval.ptr), NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_column, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).b2);;}
+#line 361 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).i1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_column, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).b2);}
+#line 2359 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 162:
-
-/* Line 936 of glr.c  */
-#line 362 "parse/gm_grammer.y"
+#line 362 "parse/gm_grammer.y" /* glr.c:816  */
     {
-                 ((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).i1, GM_expr_ival(1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_column), (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (5))].yystate.yysemantics.yysval.ptr),  (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yyloc).first_column,(((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.pair).b2);;}
+                 ((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).i1, GM_expr_ival(1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_column), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr),  (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yyloc).first_column,(((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.pair).b2);}
+#line 2366 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 163:
-
-/* Line 936 of glr.c  */
-#line 364 "parse/gm_grammer.y"
+#line 364 "parse/gm_grammer.y" /* glr.c:816  */
     {
-                 ((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.pair).i1, GM_expr_ival(1, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_column), NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yyloc).first_column, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.pair).b2);;}
+                 ((*yyvalp).ptr) = GM_expr_reduceop((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).p1, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).p2, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).i1, GM_expr_ival(1, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column), NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).p3, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.pair).b2);}
+#line 2373 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 164:
-
-/* Line 936 of glr.c  */
-#line 367 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_MOD, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 367 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_MOD, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2379 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 165:
-
-/* Line 936 of glr.c  */
-#line 368 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_MULT, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 368 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_MULT, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2385 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 166:
-
-/* Line 936 of glr.c  */
-#line 369 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_DIV, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 369 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_DIV, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2391 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 167:
-
-/* Line 936 of glr.c  */
-#line 370 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_ADD, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 370 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_ADD, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2397 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 168:
-
-/* Line 936 of glr.c  */
-#line 371 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_SUB, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 371 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_biop((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_SUB, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2403 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 169:
-
-/* Line 936 of glr.c  */
-#line 372 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_LE, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 372 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_LE, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2409 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 170:
-
-/* Line 936 of glr.c  */
-#line 373 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_GE, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 373 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_GE, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2415 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 171:
-
-/* Line 936 of glr.c  */
-#line 374 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_LT, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 374 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_LT, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2421 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 172:
-
-/* Line 936 of glr.c  */
-#line 375 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_GT, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 375 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_GT, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2427 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 173:
-
-/* Line 936 of glr.c  */
-#line 376 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_EQ, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 376 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_EQ, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2433 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 174:
-
-/* Line 936 of glr.c  */
-#line 377 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_NEQ, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 377 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_comp((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_NEQ, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2439 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 175:
-
-/* Line 936 of glr.c  */
-#line 378 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_lbiop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_AND, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 378 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_lbiop((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_AND, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2445 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 176:
-
-/* Line 936 of glr.c  */
-#line 379 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_lbiop((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), GMOP_OR, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yyloc).first_column);;}
+#line 379 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_lbiop((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), GMOP_OR, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);}
+#line 2451 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 177:
-
-/* Line 936 of glr.c  */
-#line 381 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr)= GM_expr_ternary((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (5))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (5))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((5) - (5))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yyloc).first_column);;}
+#line 381 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr)= GM_expr_ternary((((yyGLRStackItem const *)yyvsp)[YYFILL (-4)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yyloc).first_column);}
+#line 2457 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 178:
-
-/* Line 936 of glr.c  */
-#line 383 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_bval((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.bval), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 383 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_bval((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.bval), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 2463 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 179:
-
-/* Line 936 of glr.c  */
-#line 384 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_ival((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 384 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_ival((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ival), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 2469 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 180:
-
-/* Line 936 of glr.c  */
-#line 385 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_fval((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.fval), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 385 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_fval((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.fval), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 2475 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 181:
-
-/* Line 936 of glr.c  */
-#line 386 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_inf((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.bval), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 386 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_inf((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.bval), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 2481 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 182:
-
-/* Line 936 of glr.c  */
-#line 387 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_nil((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column);;}
+#line 387 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_nil((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column);}
+#line 2487 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 183:
-
-/* Line 936 of glr.c  */
-#line 388 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_id_access((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr));;}
+#line 388 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_id_access((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 2493 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 184:
-
-/* Line 936 of glr.c  */
-#line 389 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_expr_field_access((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr));;}
+#line 389 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_expr_field_access((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 2499 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 185:
-
-/* Line 936 of glr.c  */
-#line 390 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 390 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 2505 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 186:
-
-/* Line 936 of glr.c  */
-#line 391 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr);;}
+#line 391 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr);}
+#line 2511 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 187:
-
-/* Line 936 of glr.c  */
-#line 392 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_expr_map_access((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column); ;}
+#line 392 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_expr_map_access((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column); }
+#line 2517 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 188:
-
-/* Line 936 of glr.c  */
-#line 395 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 395 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 2523 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 189:
-
-/* Line 936 of glr.c  */
-#line 398 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_PLUS; ;}
+#line 398 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_PLUS; }
+#line 2529 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 190:
-
-/* Line 936 of glr.c  */
-#line 399 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MULT; ;}
+#line 399 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MULT; }
+#line 2535 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 191:
-
-/* Line 936 of glr.c  */
-#line 400 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MIN;  ;}
+#line 400 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MIN;  }
+#line 2541 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 192:
-
-/* Line 936 of glr.c  */
-#line 401 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_MAX;  ;}
+#line 401 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_MAX;  }
+#line 2547 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 193:
-
-/* Line 936 of glr.c  */
-#line 402 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_OR;  ;}
+#line 402 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_OR;  }
+#line 2553 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 194:
-
-/* Line 936 of glr.c  */
-#line 403 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_AND;  ;}
+#line 403 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_AND;  }
+#line 2559 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 195:
-
-/* Line 936 of glr.c  */
-#line 404 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_AVG;  /* syntactic sugar*/;}
+#line 404 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_AVG;  /* syntactic sugar*/}
+#line 2565 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 196:
-
-/* Line 936 of glr.c  */
-#line 406 "parse/gm_grammer.y"
-    {((*yyvalp).ival) = GMREDUCE_PLUS; ;}
+#line 406 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ival) = GMREDUCE_PLUS; }
+#line 2571 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 197:
-
-/* Line 936 of glr.c  */
-#line 409 "parse/gm_grammer.y"
-    {((*yyvalp).bval) = true;;}
+#line 409 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).bval) = true;}
+#line 2577 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 198:
-
-/* Line 936 of glr.c  */
-#line 410 "parse/gm_grammer.y"
-    {((*yyvalp).bval) = false;;}
+#line 410 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).bval) = false;}
+#line 2583 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 199:
-
-/* Line 936 of glr.c  */
-#line 412 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 412 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 2589 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 200:
-
-/* Line 936 of glr.c  */
-#line 413 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 413 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 2595 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 201:
-
-/* Line 936 of glr.c  */
-#line 414 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 414 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 2601 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 202:
-
-/* Line 936 of glr.c  */
-#line 416 "parse/gm_grammer.y"
-    { ((*yyvalp).l_list) = GM_single_lhs_list((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr));;}
+#line 416 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).l_list) = GM_single_lhs_list((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 2607 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 203:
-
-/* Line 936 of glr.c  */
-#line 417 "parse/gm_grammer.y"
-    { ((*yyvalp).l_list) = GM_add_lhs_list_front((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.l_list));;}
+#line 417 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).l_list) = GM_add_lhs_list_front((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.l_list));}
+#line 2613 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 204:
-
-/* Line 936 of glr.c  */
-#line 419 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr); ;}
+#line 419 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr); }
+#line 2619 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 205:
-
-/* Line 936 of glr.c  */
-#line 420 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_field((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.ptr), false); ;}
+#line 420 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_field((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), false); }
+#line 2625 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 206:
-
-/* Line 936 of glr.c  */
-#line 422 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_field((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (6))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((6) - (6))].yystate.yysemantics.yysval.ptr), true);  ;}
+#line 422 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_field((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr), true);  }
+#line 2631 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 207:
-
-/* Line 936 of glr.c  */
-#line 424 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_map_access((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr)); ;}
+#line 424 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_map_access((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr)); }
+#line 2637 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 208:
-
-/* Line 936 of glr.c  */
-#line 426 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_expr_builtin_expr((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.e_list));;}
+#line 426 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_expr_builtin_expr((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.e_list));}
+#line 2643 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 209:
-
-/* Line 936 of glr.c  */
-#line 427 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_expr_builtin_expr(NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (2))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (2))].yystate.yysemantics.yysval.e_list));;}
+#line 427 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_expr_builtin_expr(NULL, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.e_list));}
+#line 2649 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 210:
-
-/* Line 936 of glr.c  */
-#line 428 "parse/gm_grammer.y"
-    { ((*yyvalp).ptr) = GM_expr_builtin_field_expr((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (4))].yystate.yysemantics.yysval.e_list));;}
+#line 428 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).ptr) = GM_expr_builtin_field_expr((((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.e_list));}
+#line 2655 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 211:
-
-/* Line 936 of glr.c  */
-#line 430 "parse/gm_grammer.y"
-    { ((*yyvalp).e_list) = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (3))].yystate.yysemantics.yysval.e_list);;}
+#line 430 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).e_list) = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.e_list);}
+#line 2661 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 212:
-
-/* Line 936 of glr.c  */
-#line 431 "parse/gm_grammer.y"
-    { ((*yyvalp).e_list) = GM_empty_expr_list();;}
+#line 431 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).e_list) = GM_empty_expr_list();}
+#line 2667 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 213:
-
-/* Line 936 of glr.c  */
-#line 433 "parse/gm_grammer.y"
-    { ((*yyvalp).e_list) = GM_single_expr_list((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.ptr));;}
+#line 433 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).e_list) = GM_single_expr_list((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.ptr));}
+#line 2673 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 214:
-
-/* Line 936 of glr.c  */
-#line 434 "parse/gm_grammer.y"
-    { ((*yyvalp).e_list) = GM_add_expr_front((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (3))].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (3))].yystate.yysemantics.yysval.e_list));;}
+#line 434 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).e_list) = GM_add_expr_front((((yyGLRStackItem const *)yyvsp)[YYFILL (-2)].yystate.yysemantics.yysval.ptr), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.e_list));}
+#line 2679 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 215:
-
-/* Line 936 of glr.c  */
-#line 436 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).l_list = (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (5))].yystate.yysemantics.yysval.l_list);;}
+#line 436 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).l_list = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.l_list);}
+#line 2685 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 216:
-
-/* Line 936 of glr.c  */
-#line 437 "parse/gm_grammer.y"
-    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL ((2) - (5))].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).e_list = (((yyGLRStackItem const *)yyvsp)[YYFILL ((4) - (5))].yystate.yysemantics.yysval.e_list);;}
+#line 437 "parse/gm_grammer.y" /* glr.c:816  */
+    { ((*yyvalp).pair).p1 = (((yyGLRStackItem const *)yyvsp)[YYFILL (-3)].yystate.yysemantics.yysval.ptr); ((*yyvalp).pair).e_list = (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.e_list);}
+#line 2691 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 217:
-
-/* Line 936 of glr.c  */
-#line 440 "parse/gm_grammer.y"
-    {GM_lex_begin_user_text();;}
+#line 440 "parse/gm_grammer.y" /* glr.c:816  */
+    {GM_lex_begin_user_text();}
+#line 2697 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 218:
-
-/* Line 936 of glr.c  */
-#line 441 "parse/gm_grammer.y"
+#line 441 "parse/gm_grammer.y" /* glr.c:816  */
     { 
-                                            ((*yyvalp).ptr) = GM_expr_foreign((((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yysemantics.yysval.text), (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((3) - (4))].yystate.yyloc).first_column);
-                                          ;}
+                                            ((*yyvalp).ptr) = GM_expr_foreign((((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yysemantics.yysval.text), (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (-1)].yystate.yyloc).first_column);
+                                          }
+#line 2705 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
   case 219:
-
-/* Line 936 of glr.c  */
-#line 446 "parse/gm_grammer.y"
-    {((*yyvalp).ptr) = GM_id((((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yysemantics.yysval.text), (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL ((1) - (1))].yystate.yyloc).first_column); ;}
+#line 446 "parse/gm_grammer.y" /* glr.c:816  */
+    {((*yyvalp).ptr) = GM_id((((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yysemantics.yysval.text), (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_line, (((yyGLRStackItem const *)yyvsp)[YYFILL (0)].yystate.yyloc).first_column); }
+#line 2711 "./parse/gm_grammer.tab.c" /* glr.c:816  */
     break;
 
 
-
-/* Line 936 of glr.c  */
-#line 2977 "./parse/gm_grammer.tab.c"
+#line 2715 "./parse/gm_grammer.tab.c" /* glr.c:816  */
       default: break;
     }
 
@@ -2986,9 +2724,9 @@ yyuserAction (yyRuleNum yyn, int yyrhslen, yyGLRStackItem* yyvsp,
 # undef yyclearin
 # undef YYRECOVERING
 }
-
 
-/*ARGSUSED*/ static void
+
+static void
 yyuserMerge (int yyn, YYSTYPE* yy0, YYSTYPE* yy1)
 {
   YYUSE (yy0);
@@ -2996,34 +2734,29 @@ yyuserMerge (int yyn, YYSTYPE* yy0, YYSTYPE* yy1)
 
   switch (yyn)
     {
-      
+
       default: break;
     }
 }
 
-			      /* Bison grammar-table manipulation.  */
+                              /* Bison grammar-table manipulation.  */
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
 static void
 yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
 {
   YYUSE (yyvaluep);
   YYUSE (yylocationp);
-
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
-  switch (yytype)
-    {
-
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 /** Number of symbols composing the right hand side of rule #RULE.  */
@@ -3038,82 +2771,81 @@ yydestroyGLRState (char const *yymsg, yyGLRState *yys)
 {
   if (yys->yyresolved)
     yydestruct (yymsg, yystos[yys->yylrState],
-		&yys->yysemantics.yysval, &yys->yyloc);
+                &yys->yysemantics.yysval, &yys->yyloc);
   else
     {
 #if YYDEBUG
       if (yydebug)
-	{
-	  if (yys->yysemantics.yyfirstVal)
-	    YYFPRINTF (stderr, "%s unresolved ", yymsg);
-	  else
-	    YYFPRINTF (stderr, "%s incomplete ", yymsg);
-	  yy_symbol_print (stderr, yystos[yys->yylrState],
-			   NULL, &yys->yyloc);
-	  YYFPRINTF (stderr, "\n");
-	}
+        {
+          if (yys->yysemantics.yyfirstVal)
+            YYFPRINTF (stderr, "%s unresolved", yymsg);
+          else
+            YYFPRINTF (stderr, "%s incomplete", yymsg);
+          YY_SYMBOL_PRINT ("", yystos[yys->yylrState], YY_NULLPTR, &yys->yyloc);
+        }
 #endif
 
       if (yys->yysemantics.yyfirstVal)
-	{
-	  yySemanticOption *yyoption = yys->yysemantics.yyfirstVal;
-	  yyGLRState *yyrh;
-	  int yyn;
-	  for (yyrh = yyoption->yystate, yyn = yyrhsLength (yyoption->yyrule);
-	       yyn > 0;
-	       yyrh = yyrh->yypred, yyn -= 1)
-	    yydestroyGLRState (yymsg, yyrh);
-	}
+        {
+          yySemanticOption *yyoption = yys->yysemantics.yyfirstVal;
+          yyGLRState *yyrh;
+          int yyn;
+          for (yyrh = yyoption->yystate, yyn = yyrhsLength (yyoption->yyrule);
+               yyn > 0;
+               yyrh = yyrh->yypred, yyn -= 1)
+            yydestroyGLRState (yymsg, yyrh);
+        }
     }
 }
 
-/** Left-hand-side symbol for rule #RULE.  */
+/** Left-hand-side symbol for rule #YYRULE.  */
 static inline yySymbol
 yylhsNonterm (yyRuleNum yyrule)
 {
   return yyr1[yyrule];
 }
 
-#define yyis_pact_ninf(yystate) \
-  ((yystate) == YYPACT_NINF)
+#define yypact_value_is_default(Yystate) \
+  (!!((Yystate) == (-292)))
 
-/** True iff LR state STATE has only a default reduction (regardless
+/** True iff LR state YYSTATE has only a default reduction (regardless
  *  of token).  */
 static inline yybool
 yyisDefaultedState (yyStateNum yystate)
 {
-  return yyis_pact_ninf (yypact[yystate]);
+  return yypact_value_is_default (yypact[yystate]);
 }
 
-/** The default reduction for STATE, assuming it has one.  */
+/** The default reduction for YYSTATE, assuming it has one.  */
 static inline yyRuleNum
 yydefaultAction (yyStateNum yystate)
 {
   return yydefact[yystate];
 }
 
-#define yyis_table_ninf(yytable_value) \
-  YYID (0)
+#define yytable_value_is_error(Yytable_value) \
+  0
 
 /** Set *YYACTION to the action to take in YYSTATE on seeing YYTOKEN.
  *  Result R means
  *    R < 0:  Reduce on rule -R.
  *    R = 0:  Error.
  *    R > 0:  Shift to state R.
- *  Set *CONFLICTS to a pointer into yyconfl to 0-terminated list of
- *  conflicting reductions.
+ *  Set *YYCONFLICTS to a pointer into yyconfl to a 0-terminated list
+ *  of conflicting reductions.
  */
 static inline void
 yygetLRActions (yyStateNum yystate, int yytoken,
-		int* yyaction, const short int** yyconflicts)
+                int* yyaction, const short int** yyconflicts)
 {
   int yyindex = yypact[yystate] + yytoken;
-  if (yyindex < 0 || YYLAST < yyindex || yycheck[yyindex] != yytoken)
+  if (yypact_value_is_default (yypact[yystate])
+      || yyindex < 0 || YYLAST < yyindex || yycheck[yyindex] != yytoken)
     {
       *yyaction = -yydefact[yystate];
       *yyconflicts = yyconfl;
     }
-  else if (! yyis_table_ninf (yytable[yyindex]))
+  else if (! yytable_value_is_error (yytable[yyindex]))
     {
       *yyaction = yytable[yyindex];
       *yyconflicts = yyconfl + yyconflp[yyindex];
@@ -3125,15 +2857,18 @@ yygetLRActions (yyStateNum yystate, int yytoken,
     }
 }
 
+/** Compute post-reduction state.
+ * \param yystate   the current state
+ * \param yysym     the nonterminal to push on the stack
+ */
 static inline yyStateNum
-yyLRgotoState (yyStateNum yystate, yySymbol yylhs)
+yyLRgotoState (yyStateNum yystate, yySymbol yysym)
 {
-  int yyr;
-  yyr = yypgoto[yylhs - YYNTOKENS] + yystate;
+  int yyr = yypgoto[yysym - YYNTOKENS] + yystate;
   if (0 <= yyr && yyr <= YYLAST && yycheck[yyr] == yystate)
     return yytable[yyr];
   else
-    return yydefgoto[yylhs - YYNTOKENS];
+    return yydefgoto[yysym - YYNTOKENS];
 }
 
 static inline yybool
@@ -3148,11 +2883,12 @@ yyisErrorAction (int yyaction)
   return yyaction == 0;
 }
 
-				/* GLRStates */
+                                /* GLRStates */
 
-/** Return a fresh GLRStackItem.  Callers should call
- * YY_RESERVE_GLRSTACK afterwards to make sure there is sufficient
- * headroom.  */
+/** Return a fresh GLRStackItem in YYSTACKP.  The item is an LR state
+ *  if YYISSTATE, and otherwise a semantic option.  Callers should call
+ *  YY_RESERVE_GLRSTACK afterwards to make sure there is sufficient
+ *  headroom.  */
 
 static inline yyGLRStackItem*
 yynewGLRStackItem (yyGLRStack* yystackp, yybool yyisState)
@@ -3165,16 +2901,17 @@ yynewGLRStackItem (yyGLRStack* yystackp, yybool yyisState)
 }
 
 /** Add a new semantic action that will execute the action for rule
- *  RULENUM on the semantic values in RHS to the list of
- *  alternative actions for STATE.  Assumes that RHS comes from
- *  stack #K of *STACKP. */
+ *  YYRULE on the semantic values in YYRHS to the list of
+ *  alternative actions for YYSTATE.  Assumes that YYRHS comes from
+ *  stack #YYK of *YYSTACKP. */
 static void
 yyaddDeferredAction (yyGLRStack* yystackp, size_t yyk, yyGLRState* yystate,
-		     yyGLRState* rhs, yyRuleNum yyrule)
+                     yyGLRState* yyrhs, yyRuleNum yyrule)
 {
   yySemanticOption* yynewOption =
     &yynewGLRStackItem (yystackp, yyfalse)->yyoption;
-  yynewOption->yystate = rhs;
+  YYASSERT (!yynewOption->yyisState);
+  yynewOption->yystate = yyrhs;
   yynewOption->yyrule = yyrule;
   if (yystackp->yytops.yylookaheadNeeds[yyk])
     {
@@ -3190,9 +2927,9 @@ yyaddDeferredAction (yyGLRStack* yystackp, size_t yyk, yyGLRState* yystate,
   YY_RESERVE_GLRSTACK (yystackp);
 }
 
-				/* GLRStacks */
+                                /* GLRStacks */
 
-/** Initialize SET to a singleton set containing an empty stack.  */
+/** Initialize YYSET to a singleton set containing an empty stack.  */
 static yybool
 yyinitStateSet (yyGLRStateSet* yyset)
 {
@@ -3201,7 +2938,7 @@ yyinitStateSet (yyGLRStateSet* yyset)
   yyset->yystates = (yyGLRState**) YYMALLOC (16 * sizeof yyset->yystates[0]);
   if (! yyset->yystates)
     return yyfalse;
-  yyset->yystates[0] = NULL;
+  yyset->yystates[0] = YY_NULLPTR;
   yyset->yylookaheadNeeds =
     (yybool*) YYMALLOC (16 * sizeof yyset->yylookaheadNeeds[0]);
   if (! yyset->yylookaheadNeeds)
@@ -3218,8 +2955,8 @@ static void yyfreeStateSet (yyGLRStateSet* yyset)
   YYFREE (yyset->yylookaheadNeeds);
 }
 
-/** Initialize STACK to a single empty stack, with total maximum
- *  capacity for all stacks of SIZE.  */
+/** Initialize *YYSTACKP to a single empty stack, with total maximum
+ *  capacity for all stacks of YYSIZE.  */
 static yybool
 yyinitGLRStack (yyGLRStack* yystackp, size_t yysize)
 {
@@ -3231,8 +2968,8 @@ yyinitGLRStack (yyGLRStack* yystackp, size_t yysize)
   if (!yystackp->yyitems)
     return yyfalse;
   yystackp->yynextFree = yystackp->yyitems;
-  yystackp->yysplitPoint = NULL;
-  yystackp->yylastDeleted = NULL;
+  yystackp->yysplitPoint = YY_NULLPTR;
+  yystackp->yylastDeleted = YY_NULLPTR;
   return yyinitStateSet (&yystackp->yytops);
 }
 
@@ -3241,7 +2978,7 @@ yyinitGLRStack (yyGLRStack* yystackp, size_t yysize)
 # define YYRELOC(YYFROMITEMS,YYTOITEMS,YYX,YYTYPE) \
   &((YYTOITEMS) - ((YYFROMITEMS) - (yyGLRStackItem*) (YYX)))->YYTYPE
 
-/** If STACK is expandable, extend it.  WARNING: Pointers into the
+/** If *YYSTACKP is expandable, extend it.  WARNING: Pointers into the
     stack from outside should be considered invalid after this call.
     We always expand when there are 1 or fewer items left AFTER an
     allocation, so that we can avoid having external pointers exist
@@ -3251,9 +2988,9 @@ yyexpandGLRStack (yyGLRStack* yystackp)
 {
   yyGLRStackItem* yynewItems;
   yyGLRStackItem* yyp0, *yyp1;
-  size_t yysize, yynewSize;
+  size_t yynewSize;
   size_t yyn;
-  yysize = yystackp->yynextFree - yystackp->yyitems;
+  size_t yysize = yystackp->yynextFree - yystackp->yyitems;
   if (YYMAXDEPTH - YYHEADROOM < yysize)
     yyMemoryExhausted (yystackp);
   yynewSize = 2*yysize;
@@ -3268,35 +3005,35 @@ yyexpandGLRStack (yyGLRStack* yystackp)
     {
       *yyp1 = *yyp0;
       if (*(yybool *) yyp0)
-	{
-	  yyGLRState* yys0 = &yyp0->yystate;
-	  yyGLRState* yys1 = &yyp1->yystate;
-	  if (yys0->yypred != NULL)
-	    yys1->yypred =
-	      YYRELOC (yyp0, yyp1, yys0->yypred, yystate);
-	  if (! yys0->yyresolved && yys0->yysemantics.yyfirstVal != NULL)
-	    yys1->yysemantics.yyfirstVal =
-	      YYRELOC(yyp0, yyp1, yys0->yysemantics.yyfirstVal, yyoption);
-	}
+        {
+          yyGLRState* yys0 = &yyp0->yystate;
+          yyGLRState* yys1 = &yyp1->yystate;
+          if (yys0->yypred != YY_NULLPTR)
+            yys1->yypred =
+              YYRELOC (yyp0, yyp1, yys0->yypred, yystate);
+          if (! yys0->yyresolved && yys0->yysemantics.yyfirstVal != YY_NULLPTR)
+            yys1->yysemantics.yyfirstVal =
+              YYRELOC (yyp0, yyp1, yys0->yysemantics.yyfirstVal, yyoption);
+        }
       else
-	{
-	  yySemanticOption* yyv0 = &yyp0->yyoption;
-	  yySemanticOption* yyv1 = &yyp1->yyoption;
-	  if (yyv0->yystate != NULL)
-	    yyv1->yystate = YYRELOC (yyp0, yyp1, yyv0->yystate, yystate);
-	  if (yyv0->yynext != NULL)
-	    yyv1->yynext = YYRELOC (yyp0, yyp1, yyv0->yynext, yyoption);
-	}
+        {
+          yySemanticOption* yyv0 = &yyp0->yyoption;
+          yySemanticOption* yyv1 = &yyp1->yyoption;
+          if (yyv0->yystate != YY_NULLPTR)
+            yyv1->yystate = YYRELOC (yyp0, yyp1, yyv0->yystate, yystate);
+          if (yyv0->yynext != YY_NULLPTR)
+            yyv1->yynext = YYRELOC (yyp0, yyp1, yyv0->yynext, yyoption);
+        }
     }
-  if (yystackp->yysplitPoint != NULL)
+  if (yystackp->yysplitPoint != YY_NULLPTR)
     yystackp->yysplitPoint = YYRELOC (yystackp->yyitems, yynewItems,
-				 yystackp->yysplitPoint, yystate);
+                                      yystackp->yysplitPoint, yystate);
 
   for (yyn = 0; yyn < yystackp->yytops.yysize; yyn += 1)
-    if (yystackp->yytops.yystates[yyn] != NULL)
+    if (yystackp->yytops.yystates[yyn] != YY_NULLPTR)
       yystackp->yytops.yystates[yyn] =
-	YYRELOC (yystackp->yyitems, yynewItems,
-		 yystackp->yytops.yystates[yyn], yystate);
+        YYRELOC (yystackp->yyitems, yynewItems,
+                 yystackp->yytops.yystates[yyn], yystate);
   YYFREE (yystackp->yyitems);
   yystackp->yyitems = yynewItems;
   yystackp->yynextFree = yynewItems + yysize;
@@ -3311,37 +3048,37 @@ yyfreeGLRStack (yyGLRStack* yystackp)
   yyfreeStateSet (&yystackp->yytops);
 }
 
-/** Assuming that S is a GLRState somewhere on STACK, update the
- *  splitpoint of STACK, if needed, so that it is at least as deep as
- *  S.  */
+/** Assuming that YYS is a GLRState somewhere on *YYSTACKP, update the
+ *  splitpoint of *YYSTACKP, if needed, so that it is at least as deep as
+ *  YYS.  */
 static inline void
 yyupdateSplit (yyGLRStack* yystackp, yyGLRState* yys)
 {
-  if (yystackp->yysplitPoint != NULL && yystackp->yysplitPoint > yys)
+  if (yystackp->yysplitPoint != YY_NULLPTR && yystackp->yysplitPoint > yys)
     yystackp->yysplitPoint = yys;
 }
 
-/** Invalidate stack #K in STACK.  */
+/** Invalidate stack #YYK in *YYSTACKP.  */
 static inline void
 yymarkStackDeleted (yyGLRStack* yystackp, size_t yyk)
 {
-  if (yystackp->yytops.yystates[yyk] != NULL)
+  if (yystackp->yytops.yystates[yyk] != YY_NULLPTR)
     yystackp->yylastDeleted = yystackp->yytops.yystates[yyk];
-  yystackp->yytops.yystates[yyk] = NULL;
+  yystackp->yytops.yystates[yyk] = YY_NULLPTR;
 }
 
-/** Undelete the last stack that was marked as deleted.  Can only be
-    done once after a deletion, and only when all other stacks have
+/** Undelete the last stack in *YYSTACKP that was marked as deleted.  Can
+    only be done once after a deletion, and only when all other stacks have
     been deleted.  */
 static void
 yyundeleteLastStack (yyGLRStack* yystackp)
 {
-  if (yystackp->yylastDeleted == NULL || yystackp->yytops.yysize != 0)
+  if (yystackp->yylastDeleted == YY_NULLPTR || yystackp->yytops.yysize != 0)
     return;
   yystackp->yytops.yystates[0] = yystackp->yylastDeleted;
   yystackp->yytops.yysize = 1;
   YYDPRINTF ((stderr, "Restoring last deleted stack as stack #0.\n"));
-  yystackp->yylastDeleted = NULL;
+  yystackp->yylastDeleted = YY_NULLPTR;
 }
 
 static inline void
@@ -3351,41 +3088,42 @@ yyremoveDeletes (yyGLRStack* yystackp)
   yyi = yyj = 0;
   while (yyj < yystackp->yytops.yysize)
     {
-      if (yystackp->yytops.yystates[yyi] == NULL)
-	{
-	  if (yyi == yyj)
-	    {
-	      YYDPRINTF ((stderr, "Removing dead stacks.\n"));
-	    }
-	  yystackp->yytops.yysize -= 1;
-	}
+      if (yystackp->yytops.yystates[yyi] == YY_NULLPTR)
+        {
+          if (yyi == yyj)
+            {
+              YYDPRINTF ((stderr, "Removing dead stacks.\n"));
+            }
+          yystackp->yytops.yysize -= 1;
+        }
       else
-	{
-	  yystackp->yytops.yystates[yyj] = yystackp->yytops.yystates[yyi];
-	  /* In the current implementation, it's unnecessary to copy
-	     yystackp->yytops.yylookaheadNeeds[yyi] since, after
-	     yyremoveDeletes returns, the parser immediately either enters
-	     deterministic operation or shifts a token.  However, it doesn't
-	     hurt, and the code might evolve to need it.  */
-	  yystackp->yytops.yylookaheadNeeds[yyj] =
-	    yystackp->yytops.yylookaheadNeeds[yyi];
-	  if (yyj != yyi)
-	    {
-	      YYDPRINTF ((stderr, "Rename stack %lu -> %lu.\n",
-			  (unsigned long int) yyi, (unsigned long int) yyj));
-	    }
-	  yyj += 1;
-	}
+        {
+          yystackp->yytops.yystates[yyj] = yystackp->yytops.yystates[yyi];
+          /* In the current implementation, it's unnecessary to copy
+             yystackp->yytops.yylookaheadNeeds[yyi] since, after
+             yyremoveDeletes returns, the parser immediately either enters
+             deterministic operation or shifts a token.  However, it doesn't
+             hurt, and the code might evolve to need it.  */
+          yystackp->yytops.yylookaheadNeeds[yyj] =
+            yystackp->yytops.yylookaheadNeeds[yyi];
+          if (yyj != yyi)
+            {
+              YYDPRINTF ((stderr, "Rename stack %lu -> %lu.\n",
+                          (unsigned long int) yyi, (unsigned long int) yyj));
+            }
+          yyj += 1;
+        }
       yyi += 1;
     }
 }
 
-/** Shift to a new state on stack #K of STACK, corresponding to LR state
- * LRSTATE, at input position POSN, with (resolved) semantic value SVAL.  */
+/** Shift to a new state on stack #YYK of *YYSTACKP, corresponding to LR
+ * state YYLRSTATE, at input position YYPOSN, with (resolved) semantic
+ * value *YYVALP and source location *YYLOCP.  */
 static inline void
 yyglrShift (yyGLRStack* yystackp, size_t yyk, yyStateNum yylrState,
-	    size_t yyposn,
-	    YYSTYPE* yyvalp, YYLTYPE* yylocp)
+            size_t yyposn,
+            YYSTYPE* yyvalp, YYLTYPE* yylocp)
 {
   yyGLRState* yynewState = &yynewGLRStackItem (yystackp, yytrue)->yystate;
 
@@ -3400,145 +3138,149 @@ yyglrShift (yyGLRStack* yystackp, size_t yyk, yyStateNum yylrState,
   YY_RESERVE_GLRSTACK (yystackp);
 }
 
-/** Shift stack #K of YYSTACK, to a new state corresponding to LR
+/** Shift stack #YYK of *YYSTACKP, to a new state corresponding to LR
  *  state YYLRSTATE, at input position YYPOSN, with the (unresolved)
  *  semantic value of YYRHS under the action for YYRULE.  */
 static inline void
 yyglrShiftDefer (yyGLRStack* yystackp, size_t yyk, yyStateNum yylrState,
-		 size_t yyposn, yyGLRState* rhs, yyRuleNum yyrule)
+                 size_t yyposn, yyGLRState* yyrhs, yyRuleNum yyrule)
 {
   yyGLRState* yynewState = &yynewGLRStackItem (yystackp, yytrue)->yystate;
+  YYASSERT (yynewState->yyisState);
 
   yynewState->yylrState = yylrState;
   yynewState->yyposn = yyposn;
   yynewState->yyresolved = yyfalse;
   yynewState->yypred = yystackp->yytops.yystates[yyk];
-  yynewState->yysemantics.yyfirstVal = NULL;
+  yynewState->yysemantics.yyfirstVal = YY_NULLPTR;
   yystackp->yytops.yystates[yyk] = yynewState;
 
   /* Invokes YY_RESERVE_GLRSTACK.  */
-  yyaddDeferredAction (yystackp, yyk, yynewState, rhs, yyrule);
-}
-
-/** Pop the symbols consumed by reduction #RULE from the top of stack
- *  #K of STACK, and perform the appropriate semantic action on their
- *  semantic values.  Assumes that all ambiguities in semantic values
- *  have been previously resolved.  Set *VALP to the resulting value,
- *  and *LOCP to the computed location (if any).  Return value is as
- *  for userAction.  */
-static inline YYRESULTTAG
-yydoAction (yyGLRStack* yystackp, size_t yyk, yyRuleNum yyrule,
-	    YYSTYPE* yyvalp, YYLTYPE* yylocp)
-{
-  int yynrhs = yyrhsLength (yyrule);
-
-  if (yystackp->yysplitPoint == NULL)
-    {
-      /* Standard special case: single stack.  */
-      yyGLRStackItem* rhs = (yyGLRStackItem*) yystackp->yytops.yystates[yyk];
-      YYASSERT (yyk == 0);
-      yystackp->yynextFree -= yynrhs;
-      yystackp->yyspaceLeft += yynrhs;
-      yystackp->yytops.yystates[0] = & yystackp->yynextFree[-1].yystate;
-      return yyuserAction (yyrule, yynrhs, rhs,
-			   yyvalp, yylocp, yystackp);
-    }
-  else
-    {
-      /* At present, doAction is never called in nondeterministic
-       * mode, so this branch is never taken.  It is here in
-       * anticipation of a future feature that will allow immediate
-       * evaluation of selected actions in nondeterministic mode.  */
-      int yyi;
-      yyGLRState* yys;
-      yyGLRStackItem yyrhsVals[YYMAXRHS + YYMAXLEFT + 1];
-      yys = yyrhsVals[YYMAXRHS + YYMAXLEFT].yystate.yypred
-	= yystackp->yytops.yystates[yyk];
-      if (yynrhs == 0)
-	/* Set default location.  */
-	yyrhsVals[YYMAXRHS + YYMAXLEFT - 1].yystate.yyloc = yys->yyloc;
-      for (yyi = 0; yyi < yynrhs; yyi += 1)
-	{
-	  yys = yys->yypred;
-	  YYASSERT (yys);
-	}
-      yyupdateSplit (yystackp, yys);
-      yystackp->yytops.yystates[yyk] = yys;
-      return yyuserAction (yyrule, yynrhs, yyrhsVals + YYMAXRHS + YYMAXLEFT - 1,
-			   yyvalp, yylocp, yystackp);
-    }
+  yyaddDeferredAction (yystackp, yyk, yynewState, yyrhs, yyrule);
 }
 
 #if !YYDEBUG
 # define YY_REDUCE_PRINT(Args)
 #else
-# define YY_REDUCE_PRINT(Args)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print Args;		\
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Args)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print Args;               \
+} while (0)
 
-/*----------------------------------------------------------.
-| Report that the RULE is going to be reduced on stack #K.  |
-`----------------------------------------------------------*/
+/*----------------------------------------------------------------------.
+| Report that stack #YYK of *YYSTACKP is going to be reduced by YYRULE. |
+`----------------------------------------------------------------------*/
 
-/*ARGSUSED*/ static inline void
-yy_reduce_print (yyGLRStack* yystackp, size_t yyk, yyRuleNum yyrule,
-		 YYSTYPE* yyvalp, YYLTYPE* yylocp)
+static inline void
+yy_reduce_print (int yynormal, yyGLRStackItem* yyvsp, size_t yyk,
+                 yyRuleNum yyrule)
 {
   int yynrhs = yyrhsLength (yyrule);
-  yybool yynormal __attribute__ ((__unused__)) =
-    (yystackp->yysplitPoint == NULL);
-  yyGLRStackItem* yyvsp = (yyGLRStackItem*) yystackp->yytops.yystates[yyk];
   int yylow = 1;
   int yyi;
-  YYUSE (yyvalp);
-  YYUSE (yylocp);
   YYFPRINTF (stderr, "Reducing stack %lu by rule %d (line %lu):\n",
-	     (unsigned long int) yyk, yyrule - 1,
-	     (unsigned long int) yyrline[yyrule]);
+             (unsigned long int) yyk, yyrule - 1,
+             (unsigned long int) yyrline[yyrule]);
+  if (! yynormal)
+    yyfillin (yyvsp, 1, -yynrhs);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(((yyGLRStackItem const *)yyvsp)[YYFILL ((yyi + 1) - (yynrhs))].yystate.yysemantics.yysval)
-		       , &(((yyGLRStackItem const *)yyvsp)[YYFILL ((yyi + 1) - (yynrhs))].yystate.yyloc)		       );
+      yy_symbol_print (stderr,
+                       yystos[yyvsp[yyi - yynrhs + 1].yystate.yylrState],
+                       &yyvsp[yyi - yynrhs + 1].yystate.yysemantics.yysval
+                       , &(((yyGLRStackItem const *)yyvsp)[YYFILL ((yyi + 1) - (yynrhs))].yystate.yyloc)                       );
+      if (!yyvsp[yyi - yynrhs + 1].yystate.yyresolved)
+        YYFPRINTF (stderr, " (unresolved)");
       YYFPRINTF (stderr, "\n");
     }
 }
 #endif
 
-/** Pop items off stack #K of STACK according to grammar rule RULE,
+/** Pop the symbols consumed by reduction #YYRULE from the top of stack
+ *  #YYK of *YYSTACKP, and perform the appropriate semantic action on their
+ *  semantic values.  Assumes that all ambiguities in semantic values
+ *  have been previously resolved.  Set *YYVALP to the resulting value,
+ *  and *YYLOCP to the computed location (if any).  Return value is as
+ *  for userAction.  */
+static inline YYRESULTTAG
+yydoAction (yyGLRStack* yystackp, size_t yyk, yyRuleNum yyrule,
+            YYSTYPE* yyvalp, YYLTYPE *yylocp)
+{
+  int yynrhs = yyrhsLength (yyrule);
+
+  if (yystackp->yysplitPoint == YY_NULLPTR)
+    {
+      /* Standard special case: single stack.  */
+      yyGLRStackItem* yyrhs = (yyGLRStackItem*) yystackp->yytops.yystates[yyk];
+      YYASSERT (yyk == 0);
+      yystackp->yynextFree -= yynrhs;
+      yystackp->yyspaceLeft += yynrhs;
+      yystackp->yytops.yystates[0] = & yystackp->yynextFree[-1].yystate;
+      YY_REDUCE_PRINT ((1, yyrhs, yyk, yyrule));
+      return yyuserAction (yyrule, yynrhs, yyrhs, yystackp,
+                           yyvalp, yylocp);
+    }
+  else
+    {
+      int yyi;
+      yyGLRState* yys;
+      yyGLRStackItem yyrhsVals[YYMAXRHS + YYMAXLEFT + 1];
+      yys = yyrhsVals[YYMAXRHS + YYMAXLEFT].yystate.yypred
+        = yystackp->yytops.yystates[yyk];
+      if (yynrhs == 0)
+        /* Set default location.  */
+        yyrhsVals[YYMAXRHS + YYMAXLEFT - 1].yystate.yyloc = yys->yyloc;
+      for (yyi = 0; yyi < yynrhs; yyi += 1)
+        {
+          yys = yys->yypred;
+          YYASSERT (yys);
+        }
+      yyupdateSplit (yystackp, yys);
+      yystackp->yytops.yystates[yyk] = yys;
+      YY_REDUCE_PRINT ((0, yyrhsVals + YYMAXRHS + YYMAXLEFT - 1, yyk, yyrule));
+      return yyuserAction (yyrule, yynrhs, yyrhsVals + YYMAXRHS + YYMAXLEFT - 1,
+                           yystackp, yyvalp, yylocp);
+    }
+}
+
+/** Pop items off stack #YYK of *YYSTACKP according to grammar rule YYRULE,
  *  and push back on the resulting nonterminal symbol.  Perform the
- *  semantic action associated with RULE and store its value with the
- *  newly pushed state, if FORCEEVAL or if STACK is currently
+ *  semantic action associated with YYRULE and store its value with the
+ *  newly pushed state, if YYFORCEEVAL or if *YYSTACKP is currently
  *  unambiguous.  Otherwise, store the deferred semantic action with
  *  the new state.  If the new state would have an identical input
  *  position, LR state, and predecessor to an existing state on the stack,
- *  it is identified with that existing state, eliminating stack #K from
- *  the STACK.  In this case, the (necessarily deferred) semantic value is
+ *  it is identified with that existing state, eliminating stack #YYK from
+ *  *YYSTACKP.  In this case, the semantic value is
  *  added to the options for the existing state's semantic value.
  */
 static inline YYRESULTTAG
 yyglrReduce (yyGLRStack* yystackp, size_t yyk, yyRuleNum yyrule,
-	     yybool yyforceEval)
+             yybool yyforceEval)
 {
   size_t yyposn = yystackp->yytops.yystates[yyk]->yyposn;
 
-  if (yyforceEval || yystackp->yysplitPoint == NULL)
+  if (yyforceEval || yystackp->yysplitPoint == YY_NULLPTR)
     {
       YYSTYPE yysval;
       YYLTYPE yyloc;
 
-      YY_REDUCE_PRINT ((yystackp, yyk, yyrule, &yysval, &yyloc));
-      YYCHK (yydoAction (yystackp, yyk, yyrule, &yysval,
-			 &yyloc));
+      YYRESULTTAG yyflag = yydoAction (yystackp, yyk, yyrule, &yysval, &yyloc);
+      if (yyflag == yyerr && yystackp->yysplitPoint != YY_NULLPTR)
+        {
+          YYDPRINTF ((stderr, "Parse on stack %lu rejected by rule #%d.\n",
+                     (unsigned long int) yyk, yyrule - 1));
+        }
+      if (yyflag != yyok)
+        return yyflag;
       YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyrule], &yysval, &yyloc);
       yyglrShift (yystackp, yyk,
-		  yyLRgotoState (yystackp->yytops.yystates[yyk]->yylrState,
-				 yylhsNonterm (yyrule)),
-		  yyposn, &yysval, &yyloc);
+                  yyLRgotoState (yystackp->yytops.yystates[yyk]->yylrState,
+                                 yylhsNonterm (yyrule)),
+                  yyposn, &yysval, &yyloc);
     }
   else
     {
@@ -3548,35 +3290,36 @@ yyglrReduce (yyGLRStack* yystackp, size_t yyk, yyRuleNum yyrule,
       yyStateNum yynewLRState;
 
       for (yys = yystackp->yytops.yystates[yyk], yyn = yyrhsLength (yyrule);
-	   0 < yyn; yyn -= 1)
-	{
-	  yys = yys->yypred;
-	  YYASSERT (yys);
-	}
+           0 < yyn; yyn -= 1)
+        {
+          yys = yys->yypred;
+          YYASSERT (yys);
+        }
       yyupdateSplit (yystackp, yys);
       yynewLRState = yyLRgotoState (yys->yylrState, yylhsNonterm (yyrule));
       YYDPRINTF ((stderr,
-		  "Reduced stack %lu by rule #%d; action deferred.  Now in state %d.\n",
-		  (unsigned long int) yyk, yyrule - 1, yynewLRState));
+                  "Reduced stack %lu by rule #%d; action deferred.  "
+                  "Now in state %d.\n",
+                  (unsigned long int) yyk, yyrule - 1, yynewLRState));
       for (yyi = 0; yyi < yystackp->yytops.yysize; yyi += 1)
-	if (yyi != yyk && yystackp->yytops.yystates[yyi] != NULL)
-	  {
-	    yyGLRState* yyp, *yysplit = yystackp->yysplitPoint;
-	    yyp = yystackp->yytops.yystates[yyi];
-	    while (yyp != yys && yyp != yysplit && yyp->yyposn >= yyposn)
-	      {
-		if (yyp->yylrState == yynewLRState && yyp->yypred == yys)
-		  {
-		    yyaddDeferredAction (yystackp, yyk, yyp, yys0, yyrule);
-		    yymarkStackDeleted (yystackp, yyk);
-		    YYDPRINTF ((stderr, "Merging stack %lu into stack %lu.\n",
-				(unsigned long int) yyk,
-				(unsigned long int) yyi));
-		    return yyok;
-		  }
-		yyp = yyp->yypred;
-	      }
-	  }
+        if (yyi != yyk && yystackp->yytops.yystates[yyi] != YY_NULLPTR)
+          {
+            yyGLRState *yysplit = yystackp->yysplitPoint;
+            yyGLRState *yyp = yystackp->yytops.yystates[yyi];
+            while (yyp != yys && yyp != yysplit && yyp->yyposn >= yyposn)
+              {
+                if (yyp->yylrState == yynewLRState && yyp->yypred == yys)
+                  {
+                    yyaddDeferredAction (yystackp, yyk, yyp, yys0, yyrule);
+                    yymarkStackDeleted (yystackp, yyk);
+                    YYDPRINTF ((stderr, "Merging stack %lu into stack %lu.\n",
+                                (unsigned long int) yyk,
+                                (unsigned long int) yyi));
+                    return yyok;
+                  }
+                yyp = yyp->yypred;
+              }
+          }
       yystackp->yytops.yystates[yyk] = yys;
       yyglrShiftDefer (yystackp, yyk, yynewLRState, yyposn, yys0, yyrule);
     }
@@ -3586,7 +3329,7 @@ yyglrReduce (yyGLRStack* yystackp, size_t yyk, yyRuleNum yyrule,
 static size_t
 yysplitStack (yyGLRStack* yystackp, size_t yyk)
 {
-  if (yystackp->yysplitPoint == NULL)
+  if (yystackp->yysplitPoint == YY_NULLPTR)
     {
       YYASSERT (yyk == 0);
       yystackp->yysplitPoint = yystackp->yytops.yystates[yyk];
@@ -3596,27 +3339,27 @@ yysplitStack (yyGLRStack* yystackp, size_t yyk)
       yyGLRState** yynewStates;
       yybool* yynewLookaheadNeeds;
 
-      yynewStates = NULL;
+      yynewStates = YY_NULLPTR;
 
       if (yystackp->yytops.yycapacity
-	  > (YYSIZEMAX / (2 * sizeof yynewStates[0])))
-	yyMemoryExhausted (yystackp);
+          > (YYSIZEMAX / (2 * sizeof yynewStates[0])))
+        yyMemoryExhausted (yystackp);
       yystackp->yytops.yycapacity *= 2;
 
       yynewStates =
-	(yyGLRState**) YYREALLOC (yystackp->yytops.yystates,
-				  (yystackp->yytops.yycapacity
-				   * sizeof yynewStates[0]));
-      if (yynewStates == NULL)
-	yyMemoryExhausted (yystackp);
+        (yyGLRState**) YYREALLOC (yystackp->yytops.yystates,
+                                  (yystackp->yytops.yycapacity
+                                   * sizeof yynewStates[0]));
+      if (yynewStates == YY_NULLPTR)
+        yyMemoryExhausted (yystackp);
       yystackp->yytops.yystates = yynewStates;
 
       yynewLookaheadNeeds =
-	(yybool*) YYREALLOC (yystackp->yytops.yylookaheadNeeds,
-			     (yystackp->yytops.yycapacity
-			      * sizeof yynewLookaheadNeeds[0]));
-      if (yynewLookaheadNeeds == NULL)
-	yyMemoryExhausted (yystackp);
+        (yybool*) YYREALLOC (yystackp->yytops.yylookaheadNeeds,
+                             (yystackp->yytops.yycapacity
+                              * sizeof yynewLookaheadNeeds[0]));
+      if (yynewLookaheadNeeds == YY_NULLPTR)
+        yyMemoryExhausted (yystackp);
       yystackp->yytops.yylookaheadNeeds = yynewLookaheadNeeds;
     }
   yystackp->yytops.yystates[yystackp->yytops.yysize]
@@ -3627,7 +3370,7 @@ yysplitStack (yyGLRStack* yystackp, size_t yyk)
   return yystackp->yytops.yysize-1;
 }
 
-/** True iff Y0 and Y1 represent identical options at the top level.
+/** True iff YYY0 and YYY1 represent identical options at the top level.
  *  That is, they represent the same rule applied to RHS symbols
  *  that produce the same terminal symbols.  */
 static yybool
@@ -3638,19 +3381,19 @@ yyidenticalOptions (yySemanticOption* yyy0, yySemanticOption* yyy1)
       yyGLRState *yys0, *yys1;
       int yyn;
       for (yys0 = yyy0->yystate, yys1 = yyy1->yystate,
-	   yyn = yyrhsLength (yyy0->yyrule);
-	   yyn > 0;
-	   yys0 = yys0->yypred, yys1 = yys1->yypred, yyn -= 1)
-	if (yys0->yyposn != yys1->yyposn)
-	  return yyfalse;
+           yyn = yyrhsLength (yyy0->yyrule);
+           yyn > 0;
+           yys0 = yys0->yypred, yys1 = yys1->yypred, yyn -= 1)
+        if (yys0->yyposn != yys1->yyposn)
+          return yyfalse;
       return yytrue;
     }
   else
     return yyfalse;
 }
 
-/** Assuming identicalOptions (Y0,Y1), destructively merge the
- *  alternative semantic values for the RHS-symbols of Y1 and Y0.  */
+/** Assuming identicalOptions (YYY0,YYY1), destructively merge the
+ *  alternative semantic values for the RHS-symbols of YYY1 and YYY0.  */
 static void
 yymergeOptionSets (yySemanticOption* yyy0, yySemanticOption* yyy1)
 {
@@ -3662,43 +3405,41 @@ yymergeOptionSets (yySemanticOption* yyy0, yySemanticOption* yyy1)
        yys0 = yys0->yypred, yys1 = yys1->yypred, yyn -= 1)
     {
       if (yys0 == yys1)
-	break;
+        break;
       else if (yys0->yyresolved)
-	{
-	  yys1->yyresolved = yytrue;
-	  yys1->yysemantics.yysval = yys0->yysemantics.yysval;
-	}
+        {
+          yys1->yyresolved = yytrue;
+          yys1->yysemantics.yysval = yys0->yysemantics.yysval;
+        }
       else if (yys1->yyresolved)
-	{
-	  yys0->yyresolved = yytrue;
-	  yys0->yysemantics.yysval = yys1->yysemantics.yysval;
-	}
+        {
+          yys0->yyresolved = yytrue;
+          yys0->yysemantics.yysval = yys1->yysemantics.yysval;
+        }
       else
-	{
-	  yySemanticOption** yyz0p;
-	  yySemanticOption* yyz1;
-	  yyz0p = &yys0->yysemantics.yyfirstVal;
-	  yyz1 = yys1->yysemantics.yyfirstVal;
-	  while (YYID (yytrue))
-	    {
-	      if (yyz1 == *yyz0p || yyz1 == NULL)
-		break;
-	      else if (*yyz0p == NULL)
-		{
-		  *yyz0p = yyz1;
-		  break;
-		}
-	      else if (*yyz0p < yyz1)
-		{
-		  yySemanticOption* yyz = *yyz0p;
-		  *yyz0p = yyz1;
-		  yyz1 = yyz1->yynext;
-		  (*yyz0p)->yynext = yyz;
-		}
-	      yyz0p = &(*yyz0p)->yynext;
-	    }
-	  yys1->yysemantics.yyfirstVal = yys0->yysemantics.yyfirstVal;
-	}
+        {
+          yySemanticOption** yyz0p = &yys0->yysemantics.yyfirstVal;
+          yySemanticOption* yyz1 = yys1->yysemantics.yyfirstVal;
+          while (yytrue)
+            {
+              if (yyz1 == *yyz0p || yyz1 == YY_NULLPTR)
+                break;
+              else if (*yyz0p == YY_NULLPTR)
+                {
+                  *yyz0p = yyz1;
+                  break;
+                }
+              else if (*yyz0p < yyz1)
+                {
+                  yySemanticOption* yyz = *yyz0p;
+                  *yyz0p = yyz1;
+                  yyz1 = yyz1->yynext;
+                  (*yyz0p)->yynext = yyz;
+                }
+              yyz0p = &(*yyz0p)->yynext;
+            }
+          yys1->yysemantics.yyfirstVal = yys0->yysemantics.yyfirstVal;
+        }
     }
 }
 
@@ -3714,9 +3455,9 @@ yypreference (yySemanticOption* y0, yySemanticOption* y1)
   if (p0 == p1)
     {
       if (yymerger[r0] == 0 || yymerger[r0] != yymerger[r1])
-	return 0;
+        return 0;
       else
-	return 1;
+        return 1;
     }
   if (p0 == 0 || p1 == 0)
     return 0;
@@ -3728,50 +3469,46 @@ yypreference (yySemanticOption* y0, yySemanticOption* y1)
 }
 
 static YYRESULTTAG yyresolveValue (yyGLRState* yys,
-				   yyGLRStack* yystackp);
+                                   yyGLRStack* yystackp);
 
 
-/** Resolve the previous N states starting at and including state S.  If result
- *  != yyok, some states may have been left unresolved possibly with empty
- *  semantic option chains.  Regardless of whether result = yyok, each state
- *  has been left with consistent data so that yydestroyGLRState can be invoked
- *  if necessary.  */
+/** Resolve the previous YYN states starting at and including state YYS
+ *  on *YYSTACKP. If result != yyok, some states may have been left
+ *  unresolved possibly with empty semantic option chains.  Regardless
+ *  of whether result = yyok, each state has been left with consistent
+ *  data so that yydestroyGLRState can be invoked if necessary.  */
 static YYRESULTTAG
 yyresolveStates (yyGLRState* yys, int yyn,
-		 yyGLRStack* yystackp)
+                 yyGLRStack* yystackp)
 {
   if (0 < yyn)
     {
       YYASSERT (yys->yypred);
       YYCHK (yyresolveStates (yys->yypred, yyn-1, yystackp));
       if (! yys->yyresolved)
-	YYCHK (yyresolveValue (yys, yystackp));
+        YYCHK (yyresolveValue (yys, yystackp));
     }
   return yyok;
 }
 
-/** Resolve the states for the RHS of OPT, perform its user action, and return
- *  the semantic value and location.  Regardless of whether result = yyok, all
- *  RHS states have been destroyed (assuming the user action destroys all RHS
+/** Resolve the states for the RHS of YYOPT on *YYSTACKP, perform its
+ *  user action, and return the semantic value and location in *YYVALP
+ *  and *YYLOCP.  Regardless of whether result = yyok, all RHS states
+ *  have been destroyed (assuming the user action destroys all RHS
  *  semantic values if invoked).  */
 static YYRESULTTAG
 yyresolveAction (yySemanticOption* yyopt, yyGLRStack* yystackp,
-		 YYSTYPE* yyvalp, YYLTYPE* yylocp)
+                 YYSTYPE* yyvalp, YYLTYPE *yylocp)
 {
   yyGLRStackItem yyrhsVals[YYMAXRHS + YYMAXLEFT + 1];
-  int yynrhs;
-  int yychar_current;
-  YYSTYPE yylval_current;
-  YYLTYPE yylloc_current;
-  YYRESULTTAG yyflag;
-
-  yynrhs = yyrhsLength (yyopt->yyrule);
-  yyflag = yyresolveStates (yyopt->yystate, yynrhs, yystackp);
+  int yynrhs = yyrhsLength (yyopt->yyrule);
+  YYRESULTTAG yyflag =
+    yyresolveStates (yyopt->yystate, yynrhs, yystackp);
   if (yyflag != yyok)
     {
       yyGLRState *yys;
       for (yys = yyopt->yystate; yynrhs > 0; yys = yys->yypred, yynrhs -= 1)
-	yydestroyGLRState ("Cleanup: popping", yys);
+        yydestroyGLRState ("Cleanup: popping", yys);
       return yyflag;
     }
 
@@ -3779,18 +3516,20 @@ yyresolveAction (yySemanticOption* yyopt, yyGLRStack* yystackp,
   if (yynrhs == 0)
     /* Set default location.  */
     yyrhsVals[YYMAXRHS + YYMAXLEFT - 1].yystate.yyloc = yyopt->yystate->yyloc;
-  yychar_current = yychar;
-  yylval_current = yylval;
-  yylloc_current = yylloc;
-  yychar = yyopt->yyrawchar;
-  yylval = yyopt->yyval;
-  yylloc = yyopt->yyloc;
-  yyflag = yyuserAction (yyopt->yyrule, yynrhs,
-			   yyrhsVals + YYMAXRHS + YYMAXLEFT - 1,
-			   yyvalp, yylocp, yystackp);
-  yychar = yychar_current;
-  yylval = yylval_current;
-  yylloc = yylloc_current;
+  {
+    int yychar_current = yychar;
+    YYSTYPE yylval_current = yylval;
+    YYLTYPE yylloc_current = yylloc;
+    yychar = yyopt->yyrawchar;
+    yylval = yyopt->yyval;
+    yylloc = yyopt->yyloc;
+    yyflag = yyuserAction (yyopt->yyrule, yynrhs,
+                           yyrhsVals + YYMAXRHS + YYMAXLEFT - 1,
+                           yystackp, yyvalp, yylocp);
+    yychar = yychar_current;
+    yylval = yylval_current;
+    yylloc = yylloc_current;
+  }
   return yyflag;
 }
 
@@ -3806,7 +3545,7 @@ yyreportTree (yySemanticOption* yyx, int yyindent)
 
   for (yyi = yynrhs, yys = yyx->yystate; 0 < yyi; yyi -= 1, yys = yys->yypred)
     yystates[yyi] = yys;
-  if (yys == NULL)
+  if (yys == YY_NULLPTR)
     {
       yyleftmost_state.yyposn = 0;
       yystates[0] = &yyleftmost_state;
@@ -3816,35 +3555,35 @@ yyreportTree (yySemanticOption* yyx, int yyindent)
 
   if (yyx->yystate->yyposn < yys->yyposn + 1)
     YYFPRINTF (stderr, "%*s%s -> <Rule %d, empty>\n",
-	       yyindent, "", yytokenName (yylhsNonterm (yyx->yyrule)),
-	       yyx->yyrule - 1);
+               yyindent, "", yytokenName (yylhsNonterm (yyx->yyrule)),
+               yyx->yyrule - 1);
   else
     YYFPRINTF (stderr, "%*s%s -> <Rule %d, tokens %lu .. %lu>\n",
-	       yyindent, "", yytokenName (yylhsNonterm (yyx->yyrule)),
-	       yyx->yyrule - 1, (unsigned long int) (yys->yyposn + 1),
-	       (unsigned long int) yyx->yystate->yyposn);
+               yyindent, "", yytokenName (yylhsNonterm (yyx->yyrule)),
+               yyx->yyrule - 1, (unsigned long int) (yys->yyposn + 1),
+               (unsigned long int) yyx->yystate->yyposn);
   for (yyi = 1; yyi <= yynrhs; yyi += 1)
     {
       if (yystates[yyi]->yyresolved)
-	{
-	  if (yystates[yyi-1]->yyposn+1 > yystates[yyi]->yyposn)
-	    YYFPRINTF (stderr, "%*s%s <empty>\n", yyindent+2, "",
-		       yytokenName (yyrhs[yyprhs[yyx->yyrule]+yyi-1]));
-	  else
-	    YYFPRINTF (stderr, "%*s%s <tokens %lu .. %lu>\n", yyindent+2, "",
-		       yytokenName (yyrhs[yyprhs[yyx->yyrule]+yyi-1]),
-		       (unsigned long int) (yystates[yyi - 1]->yyposn + 1),
-		       (unsigned long int) yystates[yyi]->yyposn);
-	}
+        {
+          if (yystates[yyi-1]->yyposn+1 > yystates[yyi]->yyposn)
+            YYFPRINTF (stderr, "%*s%s <empty>\n", yyindent+2, "",
+                       yytokenName (yystos[yystates[yyi]->yylrState]));
+          else
+            YYFPRINTF (stderr, "%*s%s <tokens %lu .. %lu>\n", yyindent+2, "",
+                       yytokenName (yystos[yystates[yyi]->yylrState]),
+                       (unsigned long int) (yystates[yyi-1]->yyposn + 1),
+                       (unsigned long int) yystates[yyi]->yyposn);
+        }
       else
-	yyreportTree (yystates[yyi]->yysemantics.yyfirstVal, yyindent+2);
+        yyreportTree (yystates[yyi]->yysemantics.yyfirstVal, yyindent+2);
     }
 }
 #endif
 
-/*ARGSUSED*/ static YYRESULTTAG
+static YYRESULTTAG
 yyreportAmbiguity (yySemanticOption* yyx0,
-		   yySemanticOption* yyx1)
+                   yySemanticOption* yyx1)
 {
   YYUSE (yyx0);
   YYUSE (yyx1);
@@ -3862,144 +3601,139 @@ yyreportAmbiguity (yySemanticOption* yyx0,
   return yyabort;
 }
 
-/** Starting at and including state S1, resolve the location for each of the
- *  previous N1 states that is unresolved.  The first semantic option of a state
- *  is always chosen.  */
+/** Resolve the locations for each of the YYN1 states in *YYSTACKP,
+ *  ending at YYS1.  Has no effect on previously resolved states.
+ *  The first semantic option of a state is always chosen.  */
 static void
 yyresolveLocations (yyGLRState* yys1, int yyn1,
-		    yyGLRStack *yystackp)
+                    yyGLRStack *yystackp)
 {
   if (0 < yyn1)
     {
       yyresolveLocations (yys1->yypred, yyn1 - 1, yystackp);
       if (!yys1->yyresolved)
-	{
-	  yySemanticOption *yyoption;
-	  yyGLRStackItem yyrhsloc[1 + YYMAXRHS];
-	  int yynrhs;
-	  int yychar_current;
-	  YYSTYPE yylval_current;
-	  YYLTYPE yylloc_current;
-	  yyoption = yys1->yysemantics.yyfirstVal;
-	  YYASSERT (yyoption != NULL);
-	  yynrhs = yyrhsLength (yyoption->yyrule);
-	  if (yynrhs > 0)
-	    {
-	      yyGLRState *yys;
-	      int yyn;
-	      yyresolveLocations (yyoption->yystate, yynrhs,
-				  yystackp);
-	      for (yys = yyoption->yystate, yyn = yynrhs;
-		   yyn > 0;
-		   yys = yys->yypred, yyn -= 1)
-		yyrhsloc[yyn].yystate.yyloc = yys->yyloc;
-	    }
-	  else
-	    {
-	      /* Both yyresolveAction and yyresolveLocations traverse the GSS
-		 in reverse rightmost order.  It is only necessary to invoke
-		 yyresolveLocations on a subforest for which yyresolveAction
-		 would have been invoked next had an ambiguity not been
-		 detected.  Thus the location of the previous state (but not
-		 necessarily the previous state itself) is guaranteed to be
-		 resolved already.  */
-	      yyGLRState *yyprevious = yyoption->yystate;
-	      yyrhsloc[0].yystate.yyloc = yyprevious->yyloc;
-	    }
-	  yychar_current = yychar;
-	  yylval_current = yylval;
-	  yylloc_current = yylloc;
-	  yychar = yyoption->yyrawchar;
-	  yylval = yyoption->yyval;
-	  yylloc = yyoption->yyloc;
-	  YYLLOC_DEFAULT ((yys1->yyloc), yyrhsloc, yynrhs);
-	  yychar = yychar_current;
-	  yylval = yylval_current;
-	  yylloc = yylloc_current;
-	}
+        {
+          yyGLRStackItem yyrhsloc[1 + YYMAXRHS];
+          int yynrhs;
+          yySemanticOption *yyoption = yys1->yysemantics.yyfirstVal;
+          YYASSERT (yyoption != YY_NULLPTR);
+          yynrhs = yyrhsLength (yyoption->yyrule);
+          if (yynrhs > 0)
+            {
+              yyGLRState *yys;
+              int yyn;
+              yyresolveLocations (yyoption->yystate, yynrhs,
+                                  yystackp);
+              for (yys = yyoption->yystate, yyn = yynrhs;
+                   yyn > 0;
+                   yys = yys->yypred, yyn -= 1)
+                yyrhsloc[yyn].yystate.yyloc = yys->yyloc;
+            }
+          else
+            {
+              /* Both yyresolveAction and yyresolveLocations traverse the GSS
+                 in reverse rightmost order.  It is only necessary to invoke
+                 yyresolveLocations on a subforest for which yyresolveAction
+                 would have been invoked next had an ambiguity not been
+                 detected.  Thus the location of the previous state (but not
+                 necessarily the previous state itself) is guaranteed to be
+                 resolved already.  */
+              yyGLRState *yyprevious = yyoption->yystate;
+              yyrhsloc[0].yystate.yyloc = yyprevious->yyloc;
+            }
+          {
+            int yychar_current = yychar;
+            YYSTYPE yylval_current = yylval;
+            YYLTYPE yylloc_current = yylloc;
+            yychar = yyoption->yyrawchar;
+            yylval = yyoption->yyval;
+            yylloc = yyoption->yyloc;
+            YYLLOC_DEFAULT ((yys1->yyloc), yyrhsloc, yynrhs);
+            yychar = yychar_current;
+            yylval = yylval_current;
+            yylloc = yylloc_current;
+          }
+        }
     }
 }
 
-/** Resolve the ambiguity represented in state S, perform the indicated
- *  actions, and set the semantic value of S.  If result != yyok, the chain of
- *  semantic options in S has been cleared instead or it has been left
- *  unmodified except that redundant options may have been removed.  Regardless
- *  of whether result = yyok, S has been left with consistent data so that
+/** Resolve the ambiguity represented in state YYS in *YYSTACKP,
+ *  perform the indicated actions, and set the semantic value of YYS.
+ *  If result != yyok, the chain of semantic options in YYS has been
+ *  cleared instead or it has been left unmodified except that
+ *  redundant options may have been removed.  Regardless of whether
+ *  result = yyok, YYS has been left with consistent data so that
  *  yydestroyGLRState can be invoked if necessary.  */
 static YYRESULTTAG
 yyresolveValue (yyGLRState* yys, yyGLRStack* yystackp)
 {
   yySemanticOption* yyoptionList = yys->yysemantics.yyfirstVal;
-  yySemanticOption* yybest;
+  yySemanticOption* yybest = yyoptionList;
   yySemanticOption** yypp;
-  yybool yymerge;
+  yybool yymerge = yyfalse;
   YYSTYPE yysval;
   YYRESULTTAG yyflag;
   YYLTYPE *yylocp = &yys->yyloc;
 
-  yybest = yyoptionList;
-  yymerge = yyfalse;
-  for (yypp = &yyoptionList->yynext; *yypp != NULL; )
+  for (yypp = &yyoptionList->yynext; *yypp != YY_NULLPTR; )
     {
       yySemanticOption* yyp = *yypp;
 
       if (yyidenticalOptions (yybest, yyp))
-	{
-	  yymergeOptionSets (yybest, yyp);
-	  *yypp = yyp->yynext;
-	}
+        {
+          yymergeOptionSets (yybest, yyp);
+          *yypp = yyp->yynext;
+        }
       else
-	{
-	  switch (yypreference (yybest, yyp))
-	    {
-	    case 0:
-	      yyresolveLocations (yys, 1, yystackp);
-	      return yyreportAmbiguity (yybest, yyp);
-	      break;
-	    case 1:
-	      yymerge = yytrue;
-	      break;
-	    case 2:
-	      break;
-	    case 3:
-	      yybest = yyp;
-	      yymerge = yyfalse;
-	      break;
-	    default:
-	      /* This cannot happen so it is not worth a YYASSERT (yyfalse),
-		 but some compilers complain if the default case is
-		 omitted.  */
-	      break;
-	    }
-	  yypp = &yyp->yynext;
-	}
+        {
+          switch (yypreference (yybest, yyp))
+            {
+            case 0:
+              yyresolveLocations (yys, 1, yystackp);
+              return yyreportAmbiguity (yybest, yyp);
+              break;
+            case 1:
+              yymerge = yytrue;
+              break;
+            case 2:
+              break;
+            case 3:
+              yybest = yyp;
+              yymerge = yyfalse;
+              break;
+            default:
+              /* This cannot happen so it is not worth a YYASSERT (yyfalse),
+                 but some compilers complain if the default case is
+                 omitted.  */
+              break;
+            }
+          yypp = &yyp->yynext;
+        }
     }
 
   if (yymerge)
     {
       yySemanticOption* yyp;
       int yyprec = yydprec[yybest->yyrule];
-      yyflag = yyresolveAction (yybest, yystackp, &yysval,
-				yylocp);
+      yyflag = yyresolveAction (yybest, yystackp, &yysval, yylocp);
       if (yyflag == yyok)
-	for (yyp = yybest->yynext; yyp != NULL; yyp = yyp->yynext)
-	  {
-	    if (yyprec == yydprec[yyp->yyrule])
-	      {
-		YYSTYPE yysval_other;
-		YYLTYPE yydummy;
-		yyflag = yyresolveAction (yyp, yystackp, &yysval_other,
-					  &yydummy);
-		if (yyflag != yyok)
-		  {
-		    yydestruct ("Cleanup: discarding incompletely merged value for",
-				yystos[yys->yylrState],
-				&yysval, yylocp);
-		    break;
-		  }
-		yyuserMerge (yymerger[yyp->yyrule], &yysval, &yysval_other);
-	      }
-	  }
+        for (yyp = yybest->yynext; yyp != YY_NULLPTR; yyp = yyp->yynext)
+          {
+            if (yyprec == yydprec[yyp->yyrule])
+              {
+                YYSTYPE yysval_other;
+                YYLTYPE yydummy;
+                yyflag = yyresolveAction (yyp, yystackp, &yysval_other, &yydummy);
+                if (yyflag != yyok)
+                  {
+                    yydestruct ("Cleanup: discarding incompletely merged value for",
+                                yystos[yys->yylrState],
+                                &yysval, yylocp);
+                    break;
+                  }
+                yyuserMerge (yymerger[yyp->yyrule], &yysval, &yysval_other);
+              }
+          }
     }
   else
     yyflag = yyresolveAction (yybest, yystackp, &yysval, yylocp);
@@ -4010,24 +3744,24 @@ yyresolveValue (yyGLRState* yys, yyGLRStack* yystackp)
       yys->yysemantics.yysval = yysval;
     }
   else
-    yys->yysemantics.yyfirstVal = NULL;
+    yys->yysemantics.yyfirstVal = YY_NULLPTR;
   return yyflag;
 }
 
 static YYRESULTTAG
 yyresolveStack (yyGLRStack* yystackp)
 {
-  if (yystackp->yysplitPoint != NULL)
+  if (yystackp->yysplitPoint != YY_NULLPTR)
     {
       yyGLRState* yys;
       int yyn;
 
       for (yyn = 0, yys = yystackp->yytops.yystates[0];
-	   yys != yystackp->yysplitPoint;
-	   yys = yys->yypred, yyn += 1)
-	continue;
+           yys != yystackp->yysplitPoint;
+           yys = yys->yypred, yyn += 1)
+        continue;
       YYCHK (yyresolveStates (yystackp->yytops.yystates[0], yyn, yystackp
-			     ));
+                             ));
     }
   return yyok;
 }
@@ -4037,10 +3771,10 @@ yycompressStack (yyGLRStack* yystackp)
 {
   yyGLRState* yyp, *yyq, *yyr;
 
-  if (yystackp->yytops.yysize != 1 || yystackp->yysplitPoint == NULL)
+  if (yystackp->yytops.yysize != 1 || yystackp->yysplitPoint == YY_NULLPTR)
     return;
 
-  for (yyp = yystackp->yytops.yystates[0], yyq = yyp->yypred, yyr = NULL;
+  for (yyp = yystackp->yytops.yystates[0], yyq = yyp->yypred, yyr = YY_NULLPTR;
        yyp != yystackp->yysplitPoint;
        yyr = yyp, yyp = yyq, yyq = yyp->yypred)
     yyp->yypred = yyr;
@@ -4048,10 +3782,10 @@ yycompressStack (yyGLRStack* yystackp)
   yystackp->yyspaceLeft += yystackp->yynextFree - yystackp->yyitems;
   yystackp->yynextFree = ((yyGLRStackItem*) yystackp->yysplitPoint) + 1;
   yystackp->yyspaceLeft -= yystackp->yynextFree - yystackp->yyitems;
-  yystackp->yysplitPoint = NULL;
-  yystackp->yylastDeleted = NULL;
+  yystackp->yysplitPoint = YY_NULLPTR;
+  yystackp->yylastDeleted = YY_NULLPTR;
 
-  while (yyr != NULL)
+  while (yyr != YY_NULLPTR)
     {
       yystackp->yynextFree->yystate = *yyr;
       yyr = yyr->yypred;
@@ -4064,190 +3798,258 @@ yycompressStack (yyGLRStack* yystackp)
 
 static YYRESULTTAG
 yyprocessOneStack (yyGLRStack* yystackp, size_t yyk,
-		   size_t yyposn)
+                   size_t yyposn)
 {
-  int yyaction;
-  const short int* yyconflicts;
-  yyRuleNum yyrule;
-
-  while (yystackp->yytops.yystates[yyk] != NULL)
+  while (yystackp->yytops.yystates[yyk] != YY_NULLPTR)
     {
       yyStateNum yystate = yystackp->yytops.yystates[yyk]->yylrState;
       YYDPRINTF ((stderr, "Stack %lu Entering state %d\n",
-		  (unsigned long int) yyk, yystate));
+                  (unsigned long int) yyk, yystate));
 
       YYASSERT (yystate != YYFINAL);
 
       if (yyisDefaultedState (yystate))
-	{
-	  yyrule = yydefaultAction (yystate);
-	  if (yyrule == 0)
-	    {
-	      YYDPRINTF ((stderr, "Stack %lu dies.\n",
-			  (unsigned long int) yyk));
-	      yymarkStackDeleted (yystackp, yyk);
-	      return yyok;
-	    }
-	  YYCHK (yyglrReduce (yystackp, yyk, yyrule, yyfalse));
-	}
+        {
+          YYRESULTTAG yyflag;
+          yyRuleNum yyrule = yydefaultAction (yystate);
+          if (yyrule == 0)
+            {
+              YYDPRINTF ((stderr, "Stack %lu dies.\n",
+                          (unsigned long int) yyk));
+              yymarkStackDeleted (yystackp, yyk);
+              return yyok;
+            }
+          yyflag = yyglrReduce (yystackp, yyk, yyrule, yyimmediate[yyrule]);
+          if (yyflag == yyerr)
+            {
+              YYDPRINTF ((stderr,
+                          "Stack %lu dies "
+                          "(predicate failure or explicit user error).\n",
+                          (unsigned long int) yyk));
+              yymarkStackDeleted (yystackp, yyk);
+              return yyok;
+            }
+          if (yyflag != yyok)
+            return yyflag;
+        }
       else
-	{
-	  yySymbol yytoken;
-	  yystackp->yytops.yylookaheadNeeds[yyk] = yytrue;
-	  if (yychar == YYEMPTY)
-	    {
-	      YYDPRINTF ((stderr, "Reading a token: "));
-	      yychar = YYLEX;
-	    }
+        {
+          yySymbol yytoken;
+          int yyaction;
+          const short int* yyconflicts;
 
-	  if (yychar <= YYEOF)
-	    {
-	      yychar = yytoken = YYEOF;
-	      YYDPRINTF ((stderr, "Now at end of input.\n"));
-	    }
-	  else
-	    {
-	      yytoken = YYTRANSLATE (yychar);
-	      YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
-	    }
+          yystackp->yytops.yylookaheadNeeds[yyk] = yytrue;
+          if (yychar == YYEMPTY)
+            {
+              YYDPRINTF ((stderr, "Reading a token: "));
+              yychar = yylex ();
+            }
 
-	  yygetLRActions (yystate, yytoken, &yyaction, &yyconflicts);
+          if (yychar <= YYEOF)
+            {
+              yychar = yytoken = YYEOF;
+              YYDPRINTF ((stderr, "Now at end of input.\n"));
+            }
+          else
+            {
+              yytoken = YYTRANSLATE (yychar);
+              YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
+            }
 
-	  while (*yyconflicts != 0)
-	    {
-	      size_t yynewStack = yysplitStack (yystackp, yyk);
-	      YYDPRINTF ((stderr, "Splitting off stack %lu from %lu.\n",
-			  (unsigned long int) yynewStack,
-			  (unsigned long int) yyk));
-	      YYCHK (yyglrReduce (yystackp, yynewStack,
-				  *yyconflicts, yyfalse));
-	      YYCHK (yyprocessOneStack (yystackp, yynewStack,
-					yyposn));
-	      yyconflicts += 1;
-	    }
+          yygetLRActions (yystate, yytoken, &yyaction, &yyconflicts);
 
-	  if (yyisShiftAction (yyaction))
-	    break;
-	  else if (yyisErrorAction (yyaction))
-	    {
-	      YYDPRINTF ((stderr, "Stack %lu dies.\n",
-			  (unsigned long int) yyk));
-	      yymarkStackDeleted (yystackp, yyk);
-	      break;
-	    }
-	  else
-	    YYCHK (yyglrReduce (yystackp, yyk, -yyaction,
-				yyfalse));
-	}
+          while (*yyconflicts != 0)
+            {
+              YYRESULTTAG yyflag;
+              size_t yynewStack = yysplitStack (yystackp, yyk);
+              YYDPRINTF ((stderr, "Splitting off stack %lu from %lu.\n",
+                          (unsigned long int) yynewStack,
+                          (unsigned long int) yyk));
+              yyflag = yyglrReduce (yystackp, yynewStack,
+                                    *yyconflicts,
+                                    yyimmediate[*yyconflicts]);
+              if (yyflag == yyok)
+                YYCHK (yyprocessOneStack (yystackp, yynewStack,
+                                          yyposn));
+              else if (yyflag == yyerr)
+                {
+                  YYDPRINTF ((stderr, "Stack %lu dies.\n",
+                              (unsigned long int) yynewStack));
+                  yymarkStackDeleted (yystackp, yynewStack);
+                }
+              else
+                return yyflag;
+              yyconflicts += 1;
+            }
+
+          if (yyisShiftAction (yyaction))
+            break;
+          else if (yyisErrorAction (yyaction))
+            {
+              YYDPRINTF ((stderr, "Stack %lu dies.\n",
+                          (unsigned long int) yyk));
+              yymarkStackDeleted (yystackp, yyk);
+              break;
+            }
+          else
+            {
+              YYRESULTTAG yyflag = yyglrReduce (yystackp, yyk, -yyaction,
+                                                yyimmediate[-yyaction]);
+              if (yyflag == yyerr)
+                {
+                  YYDPRINTF ((stderr,
+                              "Stack %lu dies "
+                              "(predicate failure or explicit user error).\n",
+                              (unsigned long int) yyk));
+                  yymarkStackDeleted (yystackp, yyk);
+                  break;
+                }
+              else if (yyflag != yyok)
+                return yyflag;
+            }
+        }
     }
   return yyok;
 }
 
-/*ARGSUSED*/ static void
+static void
 yyreportSyntaxError (yyGLRStack* yystackp)
 {
-  if (yystackp->yyerrState == 0)
+  if (yystackp->yyerrState != 0)
+    return;
+#if ! YYERROR_VERBOSE
+  yyerror (YY_("syntax error"));
+#else
+  {
+  yySymbol yytoken = yychar == YYEMPTY ? YYEMPTY : YYTRANSLATE (yychar);
+  size_t yysize0 = yytnamerr (YY_NULLPTR, yytokenName (yytoken));
+  size_t yysize = yysize0;
+  yybool yysize_overflow = yyfalse;
+  char* yymsg = YY_NULLPTR;
+  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat. */
+  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
+  /* Number of reported tokens (one for the "unexpected", one per
+     "expected").  */
+  int yycount = 0;
+
+  /* There are many possibilities here to consider:
+     - If this state is a consistent state with a default action, then
+       the only way this function was invoked is if the default action
+       is an error action.  In that case, don't check for expected
+       tokens because there are none.
+     - The only way there can be no lookahead present (in yychar) is if
+       this state is a consistent state with a default action.  Thus,
+       detecting the absence of a lookahead is sufficient to determine
+       that there is no unexpected or expected token to report.  In that
+       case, just report a simple "syntax error".
+     - Don't assume there isn't a lookahead just because this state is a
+       consistent state with a default action.  There might have been a
+       previous inconsistent state, consistent state with a non-default
+       action, or user semantic action that manipulated yychar.
+     - Of course, the expected token list depends on states to have
+       correct lookahead information, and it depends on the parser not
+       to perform extra reductions after fetching a lookahead from the
+       scanner and before detecting a syntax error.  Thus, state merging
+       (from LALR or IELR) and default reductions corrupt the expected
+       token list.  However, the list is correct for canonical LR with
+       one exception: it will still contain any token that will not be
+       accepted due to an error action in a later state.
+  */
+  if (yytoken != YYEMPTY)
     {
-#if YYERROR_VERBOSE
-      int yyn;
-      yyn = yypact[yystackp->yytops.yystates[0]->yylrState];
-      if (YYPACT_NINF < yyn && yyn <= YYLAST)
-	{
-	  yySymbol yytoken = YYTRANSLATE (yychar);
-	  size_t yysize0 = yytnamerr (NULL, yytokenName (yytoken));
-	  size_t yysize = yysize0;
-	  size_t yysize1;
-	  yybool yysize_overflow = yyfalse;
-	  char* yymsg = NULL;
-	  enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-	  char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-	  int yyx;
-	  char *yyfmt;
-	  char const *yyf;
-	  static char const yyunexpected[] = "syntax error, unexpected %s";
-	  static char const yyexpecting[] = ", expecting %s";
-	  static char const yyor[] = " or %s";
-	  char yyformat[sizeof yyunexpected
-			+ sizeof yyexpecting - 1
-			+ ((YYERROR_VERBOSE_ARGS_MAXIMUM - 2)
-			   * (sizeof yyor - 1))];
-	  char const *yyprefix = yyexpecting;
-
-	  /* Start YYX at -YYN if negative to avoid negative indexes in
-	     YYCHECK.  */
-	  int yyxbegin = yyn < 0 ? -yyn : 0;
-
-	  /* Stay within bounds of both yycheck and yytname.  */
-	  int yychecklim = YYLAST - yyn + 1;
-	  int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-	  int yycount = 1;
-
-	  yyarg[0] = yytokenName (yytoken);
-	  yyfmt = yystpcpy (yyformat, yyunexpected);
-
-	  for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-	    if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-	      {
-		if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-		  {
-		    yycount = 1;
-		    yysize = yysize0;
-		    yyformat[sizeof yyunexpected - 1] = '\0';
-		    break;
-		  }
-		yyarg[yycount++] = yytokenName (yyx);
-		yysize1 = yysize + yytnamerr (NULL, yytokenName (yyx));
-		yysize_overflow |= yysize1 < yysize;
-		yysize = yysize1;
-		yyfmt = yystpcpy (yyfmt, yyprefix);
-		yyprefix = yyor;
-	      }
-
-	  yyf = YY_(yyformat);
-	  yysize1 = yysize + strlen (yyf);
-	  yysize_overflow |= yysize1 < yysize;
-	  yysize = yysize1;
-
-	  if (!yysize_overflow)
-	    yymsg = (char *) YYMALLOC (yysize);
-
-	  if (yymsg)
-	    {
-	      char *yyp = yymsg;
-	      int yyi = 0;
-	      while ((*yyp = *yyf))
-		{
-		  if (*yyp == '%' && yyf[1] == 's' && yyi < yycount)
-		    {
-		      yyp += yytnamerr (yyp, yyarg[yyi++]);
-		      yyf += 2;
-		    }
-		  else
-		    {
-		      yyp++;
-		      yyf++;
-		    }
-		}
-	      yyerror (yymsg);
-	      YYFREE (yymsg);
-	    }
-	  else
-	    {
-	      yyerror (YY_("syntax error"));
-	      yyMemoryExhausted (yystackp);
-	    }
-	}
-      else
-#endif /* YYERROR_VERBOSE */
-	yyerror (YY_("syntax error"));
-      yynerrs += 1;
+      int yyn = yypact[yystackp->yytops.yystates[0]->yylrState];
+      yyarg[yycount++] = yytokenName (yytoken);
+      if (!yypact_value_is_default (yyn))
+        {
+          /* Start YYX at -YYN if negative to avoid negative indexes in
+             YYCHECK.  In other words, skip the first -YYN actions for this
+             state because they are default actions.  */
+          int yyxbegin = yyn < 0 ? -yyn : 0;
+          /* Stay within bounds of both yycheck and yytname.  */
+          int yychecklim = YYLAST - yyn + 1;
+          int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+          int yyx;
+          for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+            if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR
+                && !yytable_value_is_error (yytable[yyx + yyn]))
+              {
+                if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
+                  {
+                    yycount = 1;
+                    yysize = yysize0;
+                    break;
+                  }
+                yyarg[yycount++] = yytokenName (yyx);
+                {
+                  size_t yysz = yysize + yytnamerr (YY_NULLPTR, yytokenName (yyx));
+                  yysize_overflow |= yysz < yysize;
+                  yysize = yysz;
+                }
+              }
+        }
     }
+
+  switch (yycount)
+    {
+#define YYCASE_(N, S)                   \
+      case N:                           \
+        yyformat = S;                   \
+      break
+      YYCASE_(0, YY_("syntax error"));
+      YYCASE_(1, YY_("syntax error, unexpected %s"));
+      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
+      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
+      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
+      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
+#undef YYCASE_
+    }
+
+  {
+    size_t yysz = yysize + strlen (yyformat);
+    yysize_overflow |= yysz < yysize;
+    yysize = yysz;
+  }
+
+  if (!yysize_overflow)
+    yymsg = (char *) YYMALLOC (yysize);
+
+  if (yymsg)
+    {
+      char *yyp = yymsg;
+      int yyi = 0;
+      while ((*yyp = *yyformat))
+        {
+          if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
+            {
+              yyp += yytnamerr (yyp, yyarg[yyi++]);
+              yyformat += 2;
+            }
+          else
+            {
+              yyp++;
+              yyformat++;
+            }
+        }
+      yyerror (yymsg);
+      YYFREE (yymsg);
+    }
+  else
+    {
+      yyerror (YY_("syntax error"));
+      yyMemoryExhausted (yystackp);
+    }
+  }
+#endif /* YYERROR_VERBOSE */
+  yynerrs += 1;
 }
 
 /* Recover from a syntax error on *YYSTACKP, assuming that *YYSTACKP->YYTOKENP,
    yylval, and yylloc are the syntactic category, semantic value, and location
    of the lookahead.  */
-/*ARGSUSED*/ static void
+static void
 yyrecoverSyntaxError (yyGLRStack* yystackp)
 {
   size_t yyk;
@@ -4256,55 +4058,55 @@ yyrecoverSyntaxError (yyGLRStack* yystackp)
   if (yystackp->yyerrState == 3)
     /* We just shifted the error token and (perhaps) took some
        reductions.  Skip tokens until we can proceed.  */
-    while (YYID (yytrue))
+    while (yytrue)
       {
-	yySymbol yytoken;
-	if (yychar == YYEOF)
-	  yyFail (yystackp, NULL);
-	if (yychar != YYEMPTY)
-	  {
-	    /* We throw away the lookahead, but the error range
-	       of the shifted error token must take it into account.  */
-	    yyGLRState *yys = yystackp->yytops.yystates[0];
-	    yyGLRStackItem yyerror_range[3];
-	    yyerror_range[1].yystate.yyloc = yys->yyloc;
-	    yyerror_range[2].yystate.yyloc = yylloc;
-	    YYLLOC_DEFAULT ((yys->yyloc), yyerror_range, 2);
-	    yytoken = YYTRANSLATE (yychar);
-	    yydestruct ("Error: discarding",
-			yytoken, &yylval, &yylloc);
-	  }
-	YYDPRINTF ((stderr, "Reading a token: "));
-	yychar = YYLEX;
-	if (yychar <= YYEOF)
-	  {
-	    yychar = yytoken = YYEOF;
-	    YYDPRINTF ((stderr, "Now at end of input.\n"));
-	  }
-	else
-	  {
-	    yytoken = YYTRANSLATE (yychar);
-	    YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
-	  }
-	yyj = yypact[yystackp->yytops.yystates[0]->yylrState];
-	if (yyis_pact_ninf (yyj))
-	  return;
-	yyj += yytoken;
-	if (yyj < 0 || YYLAST < yyj || yycheck[yyj] != yytoken)
-	  {
-	    if (yydefact[yystackp->yytops.yystates[0]->yylrState] != 0)
-	      return;
-	  }
-	else if (yytable[yyj] != 0 && ! yyis_table_ninf (yytable[yyj]))
-	  return;
+        yySymbol yytoken;
+        if (yychar == YYEOF)
+          yyFail (yystackp, YY_NULLPTR);
+        if (yychar != YYEMPTY)
+          {
+            /* We throw away the lookahead, but the error range
+               of the shifted error token must take it into account.  */
+            yyGLRState *yys = yystackp->yytops.yystates[0];
+            yyGLRStackItem yyerror_range[3];
+            yyerror_range[1].yystate.yyloc = yys->yyloc;
+            yyerror_range[2].yystate.yyloc = yylloc;
+            YYLLOC_DEFAULT ((yys->yyloc), yyerror_range, 2);
+            yytoken = YYTRANSLATE (yychar);
+            yydestruct ("Error: discarding",
+                        yytoken, &yylval, &yylloc);
+          }
+        YYDPRINTF ((stderr, "Reading a token: "));
+        yychar = yylex ();
+        if (yychar <= YYEOF)
+          {
+            yychar = yytoken = YYEOF;
+            YYDPRINTF ((stderr, "Now at end of input.\n"));
+          }
+        else
+          {
+            yytoken = YYTRANSLATE (yychar);
+            YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
+          }
+        yyj = yypact[yystackp->yytops.yystates[0]->yylrState];
+        if (yypact_value_is_default (yyj))
+          return;
+        yyj += yytoken;
+        if (yyj < 0 || YYLAST < yyj || yycheck[yyj] != yytoken)
+          {
+            if (yydefact[yystackp->yytops.yystates[0]->yylrState] != 0)
+              return;
+          }
+        else if (! yytable_value_is_error (yytable[yyj]))
+          return;
       }
 
   /* Reduce to one stack.  */
   for (yyk = 0; yyk < yystackp->yytops.yysize; yyk += 1)
-    if (yystackp->yytops.yystates[yyk] != NULL)
+    if (yystackp->yytops.yystates[yyk] != YY_NULLPTR)
       break;
   if (yyk >= yystackp->yytops.yysize)
-    yyFail (yystackp, NULL);
+    yyFail (yystackp, YY_NULLPTR);
   for (yyk += 1; yyk < yystackp->yytops.yysize; yyk += 1)
     yymarkStackDeleted (yystackp, yyk);
   yyremoveDeletes (yystackp);
@@ -4312,55 +4114,55 @@ yyrecoverSyntaxError (yyGLRStack* yystackp)
 
   /* Now pop stack until we find a state that shifts the error token.  */
   yystackp->yyerrState = 3;
-  while (yystackp->yytops.yystates[0] != NULL)
+  while (yystackp->yytops.yystates[0] != YY_NULLPTR)
     {
       yyGLRState *yys = yystackp->yytops.yystates[0];
       yyj = yypact[yys->yylrState];
-      if (! yyis_pact_ninf (yyj))
-	{
-	  yyj += YYTERROR;
-	  if (0 <= yyj && yyj <= YYLAST && yycheck[yyj] == YYTERROR
-	      && yyisShiftAction (yytable[yyj]))
-	    {
-	      /* Shift the error token having adjusted its location.  */
-	      YYLTYPE yyerrloc;
-	      yystackp->yyerror_range[2].yystate.yyloc = yylloc;
-	      YYLLOC_DEFAULT (yyerrloc, (yystackp->yyerror_range), 2);
-	      YY_SYMBOL_PRINT ("Shifting", yystos[yytable[yyj]],
-			       &yylval, &yyerrloc);
-	      yyglrShift (yystackp, 0, yytable[yyj],
-			  yys->yyposn, &yylval, &yyerrloc);
-	      yys = yystackp->yytops.yystates[0];
-	      break;
-	    }
-	}
+      if (! yypact_value_is_default (yyj))
+        {
+          yyj += YYTERROR;
+          if (0 <= yyj && yyj <= YYLAST && yycheck[yyj] == YYTERROR
+              && yyisShiftAction (yytable[yyj]))
+            {
+              /* Shift the error token.  */
+              /* First adjust its location.*/
+              YYLTYPE yyerrloc;
+              yystackp->yyerror_range[2].yystate.yyloc = yylloc;
+              YYLLOC_DEFAULT (yyerrloc, (yystackp->yyerror_range), 2);
+              YY_SYMBOL_PRINT ("Shifting", yystos[yytable[yyj]],
+                               &yylval, &yyerrloc);
+              yyglrShift (yystackp, 0, yytable[yyj],
+                          yys->yyposn, &yylval, &yyerrloc);
+              yys = yystackp->yytops.yystates[0];
+              break;
+            }
+        }
       yystackp->yyerror_range[1].yystate.yyloc = yys->yyloc;
-      if (yys->yypred != NULL)
-	yydestroyGLRState ("Error: popping", yys);
+      if (yys->yypred != YY_NULLPTR)
+        yydestroyGLRState ("Error: popping", yys);
       yystackp->yytops.yystates[0] = yys->yypred;
       yystackp->yynextFree -= 1;
       yystackp->yyspaceLeft += 1;
     }
-  if (yystackp->yytops.yystates[0] == NULL)
-    yyFail (yystackp, NULL);
+  if (yystackp->yytops.yystates[0] == YY_NULLPTR)
+    yyFail (yystackp, YY_NULLPTR);
 }
 
-#define YYCHK1(YYE)							     \
-  do {									     \
-    switch (YYE) {							     \
-    case yyok:								     \
-      break;								     \
-    case yyabort:							     \
-      goto yyabortlab;							     \
-    case yyaccept:							     \
-      goto yyacceptlab;							     \
-    case yyerr:								     \
-      goto yyuser_error;						     \
-    default:								     \
-      goto yybuglab;							     \
-    }									     \
-  } while (YYID (0))
-
+#define YYCHK1(YYE)                                                          \
+  do {                                                                       \
+    switch (YYE) {                                                           \
+    case yyok:                                                               \
+      break;                                                                 \
+    case yyabort:                                                            \
+      goto yyabortlab;                                                       \
+    case yyaccept:                                                           \
+      goto yyacceptlab;                                                      \
+    case yyerr:                                                              \
+      goto yyuser_error;                                                     \
+    default:                                                                 \
+      goto yybuglab;                                                         \
+    }                                                                        \
+  } while (0)
 
 /*----------.
 | yyparse.  |
@@ -4378,12 +4180,7 @@ yyparse (void)
 
   yychar = YYEMPTY;
   yylval = yyval_default;
-
-#if YYLTYPE_IS_TRIVIAL
-  yylloc.first_line   = yylloc.last_line   = 1;
-  yylloc.first_column = yylloc.last_column = 1;
-#endif
-
+  yylloc = yyloc_default;
 
   if (! yyinitGLRStack (yystackp, YYINITDEPTH))
     goto yyexhaustedlab;
@@ -4397,151 +4194,151 @@ yyparse (void)
   yyglrShift (&yystack, 0, 0, 0, &yylval, &yylloc);
   yyposn = 0;
 
-  while (YYID (yytrue))
+  while (yytrue)
     {
       /* For efficiency, we have two loops, the first of which is
-	 specialized to deterministic operation (single stack, no
-	 potential ambiguity).  */
+         specialized to deterministic operation (single stack, no
+         potential ambiguity).  */
       /* Standard mode */
-      while (YYID (yytrue))
-	{
-	  yyRuleNum yyrule;
-	  int yyaction;
-	  const short int* yyconflicts;
+      while (yytrue)
+        {
+          yyRuleNum yyrule;
+          int yyaction;
+          const short int* yyconflicts;
 
-	  yyStateNum yystate = yystack.yytops.yystates[0]->yylrState;
-	  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
-	  if (yystate == YYFINAL)
-	    goto yyacceptlab;
-	  if (yyisDefaultedState (yystate))
-	    {
-	      yyrule = yydefaultAction (yystate);
-	      if (yyrule == 0)
-		{
-		  yystack.yyerror_range[1].yystate.yyloc = yylloc;
-		  yyreportSyntaxError (&yystack);
-		  goto yyuser_error;
-		}
-	      YYCHK1 (yyglrReduce (&yystack, 0, yyrule, yytrue));
-	    }
-	  else
-	    {
-	      yySymbol yytoken;
-	      if (yychar == YYEMPTY)
-		{
-		  YYDPRINTF ((stderr, "Reading a token: "));
-		  yychar = YYLEX;
-		}
+          yyStateNum yystate = yystack.yytops.yystates[0]->yylrState;
+          YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+          if (yystate == YYFINAL)
+            goto yyacceptlab;
+          if (yyisDefaultedState (yystate))
+            {
+              yyrule = yydefaultAction (yystate);
+              if (yyrule == 0)
+                {
+               yystack.yyerror_range[1].yystate.yyloc = yylloc;
+                  yyreportSyntaxError (&yystack);
+                  goto yyuser_error;
+                }
+              YYCHK1 (yyglrReduce (&yystack, 0, yyrule, yytrue));
+            }
+          else
+            {
+              yySymbol yytoken;
+              if (yychar == YYEMPTY)
+                {
+                  YYDPRINTF ((stderr, "Reading a token: "));
+                  yychar = yylex ();
+                }
 
-	      if (yychar <= YYEOF)
-		{
-		  yychar = yytoken = YYEOF;
-		  YYDPRINTF ((stderr, "Now at end of input.\n"));
-		}
-	      else
-		{
-		  yytoken = YYTRANSLATE (yychar);
-		  YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
-		}
+              if (yychar <= YYEOF)
+                {
+                  yychar = yytoken = YYEOF;
+                  YYDPRINTF ((stderr, "Now at end of input.\n"));
+                }
+              else
+                {
+                  yytoken = YYTRANSLATE (yychar);
+                  YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
+                }
 
-	      yygetLRActions (yystate, yytoken, &yyaction, &yyconflicts);
-	      if (*yyconflicts != 0)
-		break;
-	      if (yyisShiftAction (yyaction))
-		{
-		  YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-		  yychar = YYEMPTY;
-		  yyposn += 1;
-		  yyglrShift (&yystack, 0, yyaction, yyposn, &yylval, &yylloc);
-		  if (0 < yystack.yyerrState)
-		    yystack.yyerrState -= 1;
-		}
-	      else if (yyisErrorAction (yyaction))
-		{
-		  yystack.yyerror_range[1].yystate.yyloc = yylloc;
-		  yyreportSyntaxError (&yystack);
-		  goto yyuser_error;
-		}
-	      else
-		YYCHK1 (yyglrReduce (&yystack, 0, -yyaction, yytrue));
-	    }
-	}
+              yygetLRActions (yystate, yytoken, &yyaction, &yyconflicts);
+              if (*yyconflicts != 0)
+                break;
+              if (yyisShiftAction (yyaction))
+                {
+                  YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
+                  yychar = YYEMPTY;
+                  yyposn += 1;
+                  yyglrShift (&yystack, 0, yyaction, yyposn, &yylval, &yylloc);
+                  if (0 < yystack.yyerrState)
+                    yystack.yyerrState -= 1;
+                }
+              else if (yyisErrorAction (yyaction))
+                {
+               yystack.yyerror_range[1].yystate.yyloc = yylloc;
+                  yyreportSyntaxError (&yystack);
+                  goto yyuser_error;
+                }
+              else
+                YYCHK1 (yyglrReduce (&yystack, 0, -yyaction, yytrue));
+            }
+        }
 
-      while (YYID (yytrue))
-	{
-	  yySymbol yytoken_to_shift;
-	  size_t yys;
+      while (yytrue)
+        {
+          yySymbol yytoken_to_shift;
+          size_t yys;
 
-	  for (yys = 0; yys < yystack.yytops.yysize; yys += 1)
-	    yystackp->yytops.yylookaheadNeeds[yys] = yychar != YYEMPTY;
+          for (yys = 0; yys < yystack.yytops.yysize; yys += 1)
+            yystackp->yytops.yylookaheadNeeds[yys] = yychar != YYEMPTY;
 
-	  /* yyprocessOneStack returns one of three things:
+          /* yyprocessOneStack returns one of three things:
 
-	      - An error flag.  If the caller is yyprocessOneStack, it
-		immediately returns as well.  When the caller is finally
-		yyparse, it jumps to an error label via YYCHK1.
+              - An error flag.  If the caller is yyprocessOneStack, it
+                immediately returns as well.  When the caller is finally
+                yyparse, it jumps to an error label via YYCHK1.
 
-	      - yyok, but yyprocessOneStack has invoked yymarkStackDeleted
-		(&yystack, yys), which sets the top state of yys to NULL.  Thus,
-		yyparse's following invocation of yyremoveDeletes will remove
-		the stack.
+              - yyok, but yyprocessOneStack has invoked yymarkStackDeleted
+                (&yystack, yys), which sets the top state of yys to NULL.  Thus,
+                yyparse's following invocation of yyremoveDeletes will remove
+                the stack.
 
-	      - yyok, when ready to shift a token.
+              - yyok, when ready to shift a token.
 
-	     Except in the first case, yyparse will invoke yyremoveDeletes and
-	     then shift the next token onto all remaining stacks.  This
-	     synchronization of the shift (that is, after all preceding
-	     reductions on all stacks) helps prevent double destructor calls
-	     on yylval in the event of memory exhaustion.  */
+             Except in the first case, yyparse will invoke yyremoveDeletes and
+             then shift the next token onto all remaining stacks.  This
+             synchronization of the shift (that is, after all preceding
+             reductions on all stacks) helps prevent double destructor calls
+             on yylval in the event of memory exhaustion.  */
 
-	  for (yys = 0; yys < yystack.yytops.yysize; yys += 1)
-	    YYCHK1 (yyprocessOneStack (&yystack, yys, yyposn));
-	  yyremoveDeletes (&yystack);
-	  if (yystack.yytops.yysize == 0)
-	    {
-	      yyundeleteLastStack (&yystack);
-	      if (yystack.yytops.yysize == 0)
-		yyFail (&yystack, YY_("syntax error"));
-	      YYCHK1 (yyresolveStack (&yystack));
-	      YYDPRINTF ((stderr, "Returning to deterministic operation.\n"));
-	      yystack.yyerror_range[1].yystate.yyloc = yylloc;
-	      yyreportSyntaxError (&yystack);
-	      goto yyuser_error;
-	    }
+          for (yys = 0; yys < yystack.yytops.yysize; yys += 1)
+            YYCHK1 (yyprocessOneStack (&yystack, yys, yyposn));
+          yyremoveDeletes (&yystack);
+          if (yystack.yytops.yysize == 0)
+            {
+              yyundeleteLastStack (&yystack);
+              if (yystack.yytops.yysize == 0)
+                yyFail (&yystack, YY_("syntax error"));
+              YYCHK1 (yyresolveStack (&yystack));
+              YYDPRINTF ((stderr, "Returning to deterministic operation.\n"));
+           yystack.yyerror_range[1].yystate.yyloc = yylloc;
+              yyreportSyntaxError (&yystack);
+              goto yyuser_error;
+            }
 
-	  /* If any yyglrShift call fails, it will fail after shifting.  Thus,
-	     a copy of yylval will already be on stack 0 in the event of a
-	     failure in the following loop.  Thus, yychar is set to YYEMPTY
-	     before the loop to make sure the user destructor for yylval isn't
-	     called twice.  */
-	  yytoken_to_shift = YYTRANSLATE (yychar);
-	  yychar = YYEMPTY;
-	  yyposn += 1;
-	  for (yys = 0; yys < yystack.yytops.yysize; yys += 1)
-	    {
-	      int yyaction;
-	      const short int* yyconflicts;
-	      yyStateNum yystate = yystack.yytops.yystates[yys]->yylrState;
-	      yygetLRActions (yystate, yytoken_to_shift, &yyaction,
-			      &yyconflicts);
-	      /* Note that yyconflicts were handled by yyprocessOneStack.  */
-	      YYDPRINTF ((stderr, "On stack %lu, ", (unsigned long int) yys));
-	      YY_SYMBOL_PRINT ("shifting", yytoken_to_shift, &yylval, &yylloc);
-	      yyglrShift (&yystack, yys, yyaction, yyposn,
-			  &yylval, &yylloc);
-	      YYDPRINTF ((stderr, "Stack %lu now in state #%d\n",
-			  (unsigned long int) yys,
-			  yystack.yytops.yystates[yys]->yylrState));
-	    }
+          /* If any yyglrShift call fails, it will fail after shifting.  Thus,
+             a copy of yylval will already be on stack 0 in the event of a
+             failure in the following loop.  Thus, yychar is set to YYEMPTY
+             before the loop to make sure the user destructor for yylval isn't
+             called twice.  */
+          yytoken_to_shift = YYTRANSLATE (yychar);
+          yychar = YYEMPTY;
+          yyposn += 1;
+          for (yys = 0; yys < yystack.yytops.yysize; yys += 1)
+            {
+              int yyaction;
+              const short int* yyconflicts;
+              yyStateNum yystate = yystack.yytops.yystates[yys]->yylrState;
+              yygetLRActions (yystate, yytoken_to_shift, &yyaction,
+                              &yyconflicts);
+              /* Note that yyconflicts were handled by yyprocessOneStack.  */
+              YYDPRINTF ((stderr, "On stack %lu, ", (unsigned long int) yys));
+              YY_SYMBOL_PRINT ("shifting", yytoken_to_shift, &yylval, &yylloc);
+              yyglrShift (&yystack, yys, yyaction, yyposn,
+                          &yylval, &yylloc);
+              YYDPRINTF ((stderr, "Stack %lu now in state #%d\n",
+                          (unsigned long int) yys,
+                          yystack.yytops.yystates[yys]->yylrState));
+            }
 
-	  if (yystack.yytops.yysize == 1)
-	    {
-	      YYCHK1 (yyresolveStack (&yystack));
-	      YYDPRINTF ((stderr, "Returning to deterministic operation.\n"));
-	      yycompressStack (&yystack);
-	      break;
-	    }
-	}
+          if (yystack.yytops.yysize == 1)
+            {
+              YYCHK1 (yyresolveStack (&yystack));
+              YYDPRINTF ((stderr, "Returning to deterministic operation.\n"));
+              yycompressStack (&yystack);
+              break;
+            }
+        }
       continue;
     yyuser_error:
       yyrecoverSyntaxError (&yystack);
@@ -4568,8 +4365,7 @@ yyparse (void)
  yyreturn:
   if (yychar != YYEMPTY)
     yydestruct ("Cleanup: discarding lookahead",
-		YYTRANSLATE (yychar),
-		&yylval, &yylloc);
+                YYTRANSLATE (yychar), &yylval, &yylloc);
 
   /* If the stack is well-formed, pop the stack until it is empty,
      destroying its entries as we go.  But free the stack regardless
@@ -4578,38 +4374,33 @@ yyparse (void)
     {
       yyGLRState** yystates = yystack.yytops.yystates;
       if (yystates)
-	{
-	  size_t yysize = yystack.yytops.yysize;
-	  size_t yyk;
-	  for (yyk = 0; yyk < yysize; yyk += 1)
-	    if (yystates[yyk])
-	      {
-		while (yystates[yyk])
-		  {
-		    yyGLRState *yys = yystates[yyk];
-		    yystack.yyerror_range[1].yystate.yyloc = yys->yyloc;
-		    if (yys->yypred != NULL)
-		      yydestroyGLRState ("Cleanup: popping", yys);
-		    yystates[yyk] = yys->yypred;
-		    yystack.yynextFree -= 1;
-		    yystack.yyspaceLeft += 1;
-		  }
-		break;
-	      }
-	}
+        {
+          size_t yysize = yystack.yytops.yysize;
+          size_t yyk;
+          for (yyk = 0; yyk < yysize; yyk += 1)
+            if (yystates[yyk])
+              {
+                while (yystates[yyk])
+                  {
+                    yyGLRState *yys = yystates[yyk];
+                 yystack.yyerror_range[1].yystate.yyloc = yys->yyloc;
+                  if (yys->yypred != YY_NULLPTR)
+                      yydestroyGLRState ("Cleanup: popping", yys);
+                    yystates[yyk] = yys->yypred;
+                    yystack.yynextFree -= 1;
+                    yystack.yyspaceLeft += 1;
+                  }
+                break;
+              }
+        }
       yyfreeGLRStack (&yystack);
     }
 
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
+  return yyresult;
 }
 
 /* DEBUGGING ONLY */
 #if YYDEBUG
-static void yypstack (yyGLRStack* yystackp, size_t yyk)
-  __attribute__ ((__unused__));
-static void yypdumpstack (yyGLRStack* yystackp) __attribute__ ((__unused__));
-
 static void
 yy_yypstack (yyGLRState* yys)
 {
@@ -4625,7 +4416,7 @@ yy_yypstack (yyGLRState* yys)
 static void
 yypstates (yyGLRState* yyst)
 {
-  if (yyst == NULL)
+  if (yyst == YY_NULLPTR)
     YYFPRINTF (stderr, "<null>");
   else
     yy_yypstack (yyst);
@@ -4638,8 +4429,8 @@ yypstack (yyGLRStack* yystackp, size_t yyk)
   yypstates (yystackp->yytops.yystates[yyk]);
 }
 
-#define YYINDEX(YYX)							     \
-    ((YYX) == NULL ? -1 : (yyGLRStackItem*) (YYX) - yystackp->yyitems)
+#define YYINDEX(YYX)                                                         \
+    ((YYX) == YY_NULLPTR ? -1 : (yyGLRStackItem*) (YYX) - yystackp->yyitems)
 
 
 static void
@@ -4652,37 +4443,44 @@ yypdumpstack (yyGLRStack* yystackp)
       YYFPRINTF (stderr, "%3lu. ",
                  (unsigned long int) (yyp - yystackp->yyitems));
       if (*(yybool *) yyp)
-	{
-	  YYFPRINTF (stderr, "Res: %d, LR State: %d, posn: %lu, pred: %ld",
-		     yyp->yystate.yyresolved, yyp->yystate.yylrState,
-		     (unsigned long int) yyp->yystate.yyposn,
-		     (long int) YYINDEX (yyp->yystate.yypred));
-	  if (! yyp->yystate.yyresolved)
-	    YYFPRINTF (stderr, ", firstVal: %ld",
-		       (long int) YYINDEX (yyp->yystate
+        {
+          YYASSERT (yyp->yystate.yyisState);
+          YYASSERT (yyp->yyoption.yyisState);
+          YYFPRINTF (stderr, "Res: %d, LR State: %d, posn: %lu, pred: %ld",
+                     yyp->yystate.yyresolved, yyp->yystate.yylrState,
+                     (unsigned long int) yyp->yystate.yyposn,
+                     (long int) YYINDEX (yyp->yystate.yypred));
+          if (! yyp->yystate.yyresolved)
+            YYFPRINTF (stderr, ", firstVal: %ld",
+                       (long int) YYINDEX (yyp->yystate
                                              .yysemantics.yyfirstVal));
-	}
+        }
       else
-	{
-	  YYFPRINTF (stderr, "Option. rule: %d, state: %ld, next: %ld",
-		     yyp->yyoption.yyrule - 1,
-		     (long int) YYINDEX (yyp->yyoption.yystate),
-		     (long int) YYINDEX (yyp->yyoption.yynext));
-	}
+        {
+          YYASSERT (!yyp->yystate.yyisState);
+          YYASSERT (!yyp->yyoption.yyisState);
+          YYFPRINTF (stderr, "Option. rule: %d, state: %ld, next: %ld",
+                     yyp->yyoption.yyrule - 1,
+                     (long int) YYINDEX (yyp->yyoption.yystate),
+                     (long int) YYINDEX (yyp->yyoption.yynext));
+        }
       YYFPRINTF (stderr, "\n");
     }
   YYFPRINTF (stderr, "Tops:");
   for (yyi = 0; yyi < yystackp->yytops.yysize; yyi += 1)
     YYFPRINTF (stderr, "%lu: %ld; ", (unsigned long int) yyi,
-	       (long int) YYINDEX (yystackp->yytops.yystates[yyi]));
+               (long int) YYINDEX (yystackp->yytops.yystates[yyi]));
   YYFPRINTF (stderr, "\n");
 }
 #endif
 
+#undef yylval
+#undef yychar
+#undef yynerrs
+#undef yylloc
 
 
-/* Line 2634 of glr.c  */
-#line 448 "parse/gm_grammer.y"
 
+#line 448 "parse/gm_grammer.y" /* glr.c:2584  */
 
 

--- a/src/parse/gm_grammer.tab.h
+++ b/src/parse/gm_grammer.tab.h
@@ -1,20 +1,19 @@
-
-/* A Bison parser, made by GNU Bison 2.4.1.  */
+/* A Bison parser, made by GNU Bison 3.0.4.  */
 
 /* Skeleton interface for Bison GLR parsers in C
-   
-      Copyright (C) 2002, 2003, 2004, 2005, 2006 Free Software Foundation, Inc.
-   
+
+   Copyright (C) 2002-2015 Free Software Foundation, Inc.
+
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
@@ -27,100 +26,107 @@
    special exception, which will cause the skeleton and the resulting
    Bison output files to be licensed under the GNU General Public
    License without this special exception.
-   
+
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     T_PROC = 258,
-     T_GRAPH = 259,
-     T_NODE = 260,
-     T_NODEPROP = 261,
-     T_EDGE = 262,
-     T_EDGEPROP = 263,
-     T_LOCAL = 264,
-     T_NSET = 265,
-     T_NORDER = 266,
-     T_NSEQ = 267,
-     T_ITEMS = 268,
-     T_COLLECTION = 269,
-     T_MAP = 270,
-     T_DFS = 271,
-     T_POST = 272,
-     T_INT = 273,
-     T_FLOAT = 274,
-     T_BOOL = 275,
-     T_DOUBLE = 276,
-     T_LONG = 277,
-     T_RETURN = 278,
-     T_BFS = 279,
-     T_RBFS = 280,
-     T_FROM = 281,
-     T_TO = 282,
-     T_BACK = 283,
-     T_FOREACH = 284,
-     T_FOR = 285,
-     T_NODES = 286,
-     T_EDGES = 287,
-     T_NBRS = 288,
-     T_IN_NBRS = 289,
-     T_UP_NBRS = 290,
-     T_DOWN_NBRS = 291,
-     T_COMMON_NBRS = 292,
-     T_SUM = 293,
-     T_PRODUCT = 294,
-     T_MIN = 295,
-     T_MAX = 296,
-     T_COUNT = 297,
-     T_ALL = 298,
-     T_EXIST = 299,
-     T_AVG = 300,
-     T_EMPTYLINE = 301,
-     T_AND = 302,
-     T_OR = 303,
-     T_EQ = 304,
-     T_NEQ = 305,
-     T_LE = 306,
-     T_GE = 307,
-     T_IF = 308,
-     T_ELSE = 309,
-     T_DO = 310,
-     T_WHILE = 311,
-     T_PLUSEQ = 312,
-     T_MULTEQ = 313,
-     T_MINEQ = 314,
-     T_MAXEQ = 315,
-     T_PLUSPLUS = 316,
-     T_MINUSMINUS = 317,
-     T_ANDEQ = 318,
-     T_OREQ = 319,
-     T_M_INF = 320,
-     T_P_INF = 321,
-     T_DOUBLE_COLON = 322,
-     T_RARROW = 323,
-     T_NIL = 324,
-     ID = 325,
-     USER_TEXT = 326,
-     INT_NUM = 327,
-     FLOAT_NUM = 328,
-     BOOL_VAL = 329,
-     NEG = 330
-   };
+#ifndef YY_YY_PARSE_GM_GRAMMER_TAB_H_INCLUDED
+# define YY_YY_PARSE_GM_GRAMMER_TAB_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 0
+#endif
+#if YYDEBUG
+extern int yydebug;
 #endif
 
+/* Token type.  */
+#ifndef YYTOKENTYPE
+# define YYTOKENTYPE
+  enum yytokentype
+  {
+    T_PROC = 258,
+    T_GRAPH = 259,
+    T_NODE = 260,
+    T_NODEPROP = 261,
+    T_EDGE = 262,
+    T_EDGEPROP = 263,
+    T_LOCAL = 264,
+    T_NSET = 265,
+    T_NORDER = 266,
+    T_NSEQ = 267,
+    T_ITEMS = 268,
+    T_COLLECTION = 269,
+    T_MAP = 270,
+    T_DFS = 271,
+    T_POST = 272,
+    T_INT = 273,
+    T_FLOAT = 274,
+    T_BOOL = 275,
+    T_DOUBLE = 276,
+    T_LONG = 277,
+    T_RETURN = 278,
+    T_BFS = 279,
+    T_RBFS = 280,
+    T_FROM = 281,
+    T_TO = 282,
+    T_BACK = 283,
+    T_FOREACH = 284,
+    T_FOR = 285,
+    T_NODES = 286,
+    T_EDGES = 287,
+    T_NBRS = 288,
+    T_IN_NBRS = 289,
+    T_UP_NBRS = 290,
+    T_DOWN_NBRS = 291,
+    T_COMMON_NBRS = 292,
+    T_SUM = 293,
+    T_PRODUCT = 294,
+    T_MIN = 295,
+    T_MAX = 296,
+    T_COUNT = 297,
+    T_ALL = 298,
+    T_EXIST = 299,
+    T_AVG = 300,
+    T_EMPTYLINE = 301,
+    T_AND = 302,
+    T_OR = 303,
+    T_EQ = 304,
+    T_NEQ = 305,
+    T_LE = 306,
+    T_GE = 307,
+    T_IF = 308,
+    T_ELSE = 309,
+    T_DO = 310,
+    T_WHILE = 311,
+    T_PLUSEQ = 312,
+    T_MULTEQ = 313,
+    T_MINEQ = 314,
+    T_MAXEQ = 315,
+    T_PLUSPLUS = 316,
+    T_MINUSMINUS = 317,
+    T_ANDEQ = 318,
+    T_OREQ = 319,
+    T_M_INF = 320,
+    T_P_INF = 321,
+    T_DOUBLE_COLON = 322,
+    T_RARROW = 323,
+    T_NIL = 324,
+    ID = 325,
+    USER_TEXT = 326,
+    INT_NUM = 327,
+    FLOAT_NUM = 328,
+    BOOL_VAL = 329,
+    NEG = 330
+  };
+#endif
 
-#ifndef YYSTYPE
-typedef union YYSTYPE
+/* Value type.  */
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
+
+union YYSTYPE
 {
-
-/* Line 2638 of glr.c  */
-#line 18 "parse/gm_grammer.y"
+#line 18 "parse/gm_grammer.y" /* glr.c:197  */
 
     int  info;
     long ival;
@@ -132,32 +138,31 @@ typedef union YYSTYPE
     lhs_list* l_list;   // list of lhs
     struct parse_temp_t pair;
 
+#line 142 "./parse/gm_grammer.tab.h" /* glr.c:197  */
+};
 
-
-/* Line 2638 of glr.c  */
-#line 139 "./parse/gm_grammer.tab.h"
-} YYSTYPE;
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
 
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
-
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-
-} YYLTYPE;
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
 
-
 extern YYSTYPE yylval;
-
 extern YYLTYPE yylloc;
+int yyparse (void);
 
-
+#endif /* !YY_YY_PARSE_GM_GRAMMER_TAB_H_INCLUDED  */

--- a/src/parse/gm_grammer.y
+++ b/src/parse/gm_grammer.y
@@ -309,7 +309,7 @@ bfs_navigator :  '[' expr ']'              {$$ = $2;}
 
   var_target: id_comma_list                   { $$ = GM_finish_id_comma_list();}
 
-  sent_assignment : lhs '=' rhs             { $$ = GM_normal_assign($1, $3); GM_set_lineinfo($$, @2.first_line, @2.first_column)}
+  sent_assignment : lhs '=' rhs             { $$ = GM_normal_assign($1, $3); GM_set_lineinfo($$, @2.first_line, @2.first_column);}
   sent_reduce_assignment : lhs reduce_eq rhs optional_bind  { $$ = GM_reduce_assign($1, $3, $4, $2); GM_set_lineinfo($$, @2.first_line, @2.first_column);}
                          | lhs T_PLUSPLUS optional_bind{ $$ = GM_reduce_assign($1, GM_expr_ival(1, @2.first_line, @2.first_column), $3, GMREDUCE_PLUS); }
                          | lhs T_MINUSMINUS optional_bind{ $$ = GM_reduce_assign($1, GM_expr_ival(-1, @2.first_line, @2.first_column), $3, GMREDUCE_PLUS); }


### PR DESCRIPTION

5965bb0: hash define of `errno` in the header `errno.h` causes linking errors. 
ef9c2a8: squash compiler warning
be214fc: adding missing `;` that prevented the grammar to be compiled. 